### PR TITLE
Fix search scoring bugs and edge cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chat-history"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chat-history"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Ayush Bhardwaj"]

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The following are automatically filtered out:
 
 Search and scoring logic ported from:
 - [claude-historian-mcp](https://github.com/Vvkmnn/claude-historian-mcp) — multi-signal relevance scoring, query similarity, importance heuristics
-- [claude-history](https://github.com/raine/claude-history) — prefix matching, separator normalization, recency multiplier
+- [claude-history](https://github.com/raine/claude-history) — prefix matching, separator normalization, recency multiplier, cwd-based project path resolution, copy-on-resume for deleted project directories
 - [search-sessions](https://github.com/sinzin91/search-sessions) — two-tier index/deep search, field-weighted scoring, natural language dates, per-session cap
 - [cursor-history](https://github.com/S2thend/cursor-history) — multi-format Cursor transcript parsing
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -3,14 +3,15 @@ use crate::parser::{clean_prompt, snippet_around_match};
 use crate::search::{IndexResult, SearchResult};
 use crate::session::{Message, Session};
 use std::collections::BTreeMap;
+use std::sync::LazyLock;
 
-fn is_color() -> bool {
+static USE_COLOR: LazyLock<bool> = LazyLock::new(|| {
     std::io::IsTerminal::is_terminal(&std::io::stdout()) && std::env::var("NO_COLOR").is_err()
-}
+});
 
 macro_rules! c {
     ($name:expr) => {
-        if is_color() {
+        if *USE_COLOR {
             match $name {
                 "reset" => "\x1b[0m",
                 "bold" => "\x1b[1m",

--- a/src/display.rs
+++ b/src/display.rs
@@ -163,10 +163,17 @@ pub fn print_search_results(results: &[SearchResult], query: &str) {
         } else {
             format!("{}Assistant{}", c!("blue"), c!("reset"))
         };
+        let display_title = if !r.session.summary.is_empty() {
+            r.session.summary.chars().take(80).collect::<String>()
+        } else if !r.session.first_prompt.is_empty() {
+            clean_prompt(&r.session.first_prompt).chars().take(80).collect::<String>()
+        } else {
+            "(no summary)".into()
+        };
         println!(
             "  {}{:3}.{} {} {}{}{} {}  {}{}{}  {}[{}]{}",
             c!("dim"), i + 1, c!("reset"), tag, c!("cyan"), r.session.date, c!("reset"),
-            score, c!("bold"), r.session.summary, c!("reset"),
+            score, c!("bold"), display_title, c!("reset"),
             c!("dim"), sid_short, c!("reset")
         );
         let snippet = snippet_around_match(&r.message.content, query, 200);

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -73,6 +73,7 @@ pub fn inspect_session(session: &Session) -> Option<InspectInfo> {
     let mut accomplishments = Vec::new();
     let mut decisions = Vec::new();
     let mut errors_seen = Vec::new();
+    let mut err_set: HashSet<String> = HashSet::new();
     let mut user_count = 0usize;
     let mut assistant_count = 0usize;
     let mut acc_set: HashSet<String> = HashSet::new();
@@ -101,7 +102,9 @@ pub fn inspect_session(session: &Session) -> Option<InspectInfo> {
             files_modified.insert(f.clone());
         }
         for e in msg.error_patterns.iter().take(3) {
-            errors_seen.push(e.clone());
+            if err_set.insert(e.clone()) {
+                errors_seen.push(e.clone());
+            }
         }
 
         if msg.role == "assistant" && msg.content.len() > 80 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,11 +255,17 @@ fn main() {
                         "Project dir {} no longer exists, copying session to current directory...",
                         session.project
                     );
-                    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
-                    let encoded = session::encode_path_for_claude(&cwd);
-                    let target = session::claude_projects_dir().join(&encoded);
-                    if let Err(e) = session::copy_session_to_dir(session, &target) {
-                        eprintln!("Warning: failed to copy session files: {e}");
+                    match std::env::current_dir() {
+                        Ok(cwd) => {
+                            let encoded = session::encode_path_for_claude(&cwd);
+                            let target = session::claude_projects_dir().join(&encoded);
+                            if let Err(e) = session::copy_session_to_dir(session, &target) {
+                                eprintln!("Warning: failed to copy session files: {e}");
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("Warning: could not determine current directory; skipping session copy: {e}");
+                        }
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ struct Cli {
     #[arg(long, global = true, help = "Filter by git branch substring")]
     branch: Option<String>,
 
-    #[arg(short = 'k', long, help = "Quick keyword filter")]
+    #[arg(short = 'k', long, global = true, help = "Quick keyword filter")]
     keyword: Option<String>,
 
     #[arg(short = 's', long, help = "Group sessions by day")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,6 +250,17 @@ fn main() {
                     if let Err(e) = std::env::set_current_dir(project) {
                         eprintln!("Warning: could not cd to {}: {e}", session.project);
                     }
+                } else {
+                    eprintln!(
+                        "Project dir {} no longer exists, copying session to current directory...",
+                        session.project
+                    );
+                    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+                    let encoded = session::encode_path_for_claude(&cwd);
+                    let target = session::claude_projects_dir().join(&encoded);
+                    if let Err(e) = session::copy_session_to_dir(session, &target) {
+                        eprintln!("Warning: failed to copy session files: {e}");
+                    }
                 }
             }
             use std::os::unix::process::CommandExt;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -166,7 +166,7 @@ pub fn clean_prompt(text: &str) -> String {
 }
 
 pub fn is_noise(text: &str) -> bool {
-    if text.len() < 40 {
+    if text.len() < 10 {
         return true;
     }
     let lower = text.to_lowercase();
@@ -265,6 +265,7 @@ pub fn snippet_around_match(text: &str, query: &str, context_chars: usize) -> St
         end
     };
 
+    let end = end.max(start);
     let snippet = &cleaned[start..end.min(cleaned.len())];
     let prefix = if start > 0 { "..." } else { "" };
     let suffix = if end < cleaned.len() { "..." } else { "" };

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -342,6 +342,7 @@ pub fn query_similarity(q1: &str, q2: &str) -> f64 {
     for word1 in &w1 {
         let mut best_match: f64 = 0.0;
         let mut best_idx: Option<usize> = None;
+        let mut best_is_sig_pair = false;
         let is_sig1 = sig1.contains(&word1.as_str());
 
         for (j, word2) in w2.iter().enumerate() {
@@ -353,17 +354,11 @@ pub fn query_similarity(q1: &str, q2: &str) -> f64 {
 
             if word1 == word2 {
                 match_score = 1.0;
-                if is_sig1 && is_sig2 {
-                    sig_matches += 1;
-                }
             } else if word1.contains(word2.as_str()) || word2.contains(word1.as_str()) {
                 let shorter = word1.len().min(word2.len());
                 let longer = word1.len().max(word2.len());
                 if shorter >= 5 && (shorter as f64 / longer as f64) >= 0.6 {
                     match_score = 0.8 * (shorter as f64 / longer as f64);
-                    if is_sig1 && is_sig2 {
-                        sig_matches += 1;
-                    }
                 }
             } else {
                 for (key, syns) in TECHNICAL_SYNONYMS.iter() {
@@ -372,9 +367,6 @@ pub fn query_similarity(q1: &str, q2: &str) -> f64 {
                         || (syns.contains(&word1.as_str()) && syns.contains(&word2.as_str()))
                     {
                         match_score = 0.7;
-                        if is_sig1 && is_sig2 {
-                            sig_matches += 1;
-                        }
                         break;
                     }
                 }
@@ -383,12 +375,16 @@ pub fn query_similarity(q1: &str, q2: &str) -> f64 {
             if match_score > best_match {
                 best_match = match_score;
                 best_idx = Some(j);
+                best_is_sig_pair = is_sig1 && is_sig2 && match_score > 0.0;
             }
         }
 
         if let Some(idx) = best_idx {
             matched2.insert(idx);
             total_score += best_match;
+            if best_is_sig_pair {
+                sig_matches += 1;
+            }
         }
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -275,6 +275,9 @@ pub fn scored_search(
                     "error_resolution" if cl.contains("error") || cl.contains("exception") => score *= bval,
                     "solutions" if cl.contains("fix") || cl.contains("resolve") => score *= bval,
                     "implementation" if cl.contains("implement") || cl.contains("create") => score *= bval,
+                    "optimization" if cl.contains("optimiz") || cl.contains("performance") || cl.contains("improve") => score *= bval,
+                    "file_operations" if cl.contains("file") || cl.contains("read") || cl.contains("write") => score *= bval,
+                    "tool_usage" if cl.contains("tool") || !msg.tool_uses.is_empty() => score *= bval,
                     _ => {}
                 }
             }

--- a/src/session.rs
+++ b/src/session.rs
@@ -298,7 +298,8 @@ pub fn load_cursor_sessions() -> Vec<Session> {
             if !transcripts.is_dir() {
                 continue;
             }
-            let mut seen_ids = HashSet::new();
+            let mut txt_ids: HashSet<String> = HashSet::new();
+            let mut dir_entries: Vec<(String, PathBuf)> = Vec::new();
             if let Ok(entries) = fs::read_dir(&transcripts) {
                 for entry in entries.flatten() {
                     let path = entry.path();
@@ -308,7 +309,7 @@ pub fn load_cursor_sessions() -> Vec<Session> {
                             .unwrap_or_default()
                             .to_string_lossy()
                             .to_string();
-                        seen_ids.insert(sid.clone());
+                        txt_ids.insert(sid.clone());
                         let jsonl_alt = transcripts.join(&sid).join(format!("{sid}.jsonl"));
                         let iso = mtime_iso(&path).unwrap_or_default();
                         let date = mtime_date(&path).unwrap_or_default();
@@ -338,32 +339,35 @@ pub fn load_cursor_sessions() -> Vec<Session> {
                             .unwrap_or_default()
                             .to_string_lossy()
                             .to_string();
-                        if seen_ids.contains(&dirname) {
-                            continue;
-                        }
-                        let jf = path.join(format!("{dirname}.jsonl"));
-                        if !jf.exists() {
-                            continue;
-                        }
-                        let iso = mtime_iso(&jf).unwrap_or_default();
-                        let date = mtime_date(&jf).unwrap_or_default();
-                        let first = cursor_first_prompt_jsonl(&jf);
-                        sessions.push(Session {
-                            source: "cursor".into(),
-                            id: dirname,
-                            summary: String::new(),
-                            first_prompt: first,
-                            created: iso.clone(),
-                            modified: iso,
-                            date,
-                            messages: 0,
-                            branch: String::new(),
-                            project: pd.file_name().to_string_lossy().to_string(),
-                            file: jf.to_string_lossy().to_string(),
-                            is_sidechain: false,
-                        });
+                        dir_entries.push((dirname, path));
                     }
                 }
+            }
+            for (dirname, path) in dir_entries {
+                if txt_ids.contains(&dirname) {
+                    continue;
+                }
+                let jf = path.join(format!("{dirname}.jsonl"));
+                if !jf.exists() {
+                    continue;
+                }
+                let iso = mtime_iso(&jf).unwrap_or_default();
+                let date = mtime_date(&jf).unwrap_or_default();
+                let first = cursor_first_prompt_jsonl(&jf);
+                sessions.push(Session {
+                    source: "cursor".into(),
+                    id: dirname,
+                    summary: String::new(),
+                    first_prompt: first,
+                    created: iso.clone(),
+                    modified: iso,
+                    date,
+                    messages: 0,
+                    branch: String::new(),
+                    project: pd.file_name().to_string_lossy().to_string(),
+                    file: jf.to_string_lossy().to_string(),
+                    is_sidechain: false,
+                });
             }
         }
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -94,7 +94,7 @@ fn dirs_next() -> Option<PathBuf> {
     std::env::var_os("HOME").map(PathBuf::from)
 }
 
-fn claude_projects_dir() -> PathBuf {
+pub fn claude_projects_dir() -> PathBuf {
     if let Ok(config_dir) = std::env::var("CLAUDE_CONFIG_DIR") {
         return PathBuf::from(config_dir).join("projects");
     }
@@ -103,6 +103,66 @@ fn claude_projects_dir() -> PathBuf {
 
 fn cursor_projects_dir() -> PathBuf {
     home_dir().join(".cursor").join("projects")
+}
+
+fn read_cwd_from_jsonl(path: &Path) -> Option<String> {
+    let file = fs::File::open(path).ok()?;
+    let reader = BufReader::new(file);
+    for line in reader.lines().take(10) {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let entry: Value = match serde_json::from_str(trimmed) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if let Some(cwd) = entry.get("cwd").and_then(Value::as_str) {
+            if !cwd.is_empty() {
+                return Some(cwd.to_string());
+            }
+        }
+    }
+    None
+}
+
+pub fn encode_path_for_claude(path: &Path) -> String {
+    path.to_string_lossy().replace('/', "-")
+}
+
+pub fn copy_session_to_dir(session: &Session, target_dir: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(target_dir)?;
+
+    let src = Path::new(&session.file);
+    if let Some(filename) = src.file_name() {
+        fs::copy(src, target_dir.join(filename))?;
+    }
+
+    if let Some(parent) = src.parent() {
+        let companion = parent.join(&session.id);
+        if companion.is_dir() {
+            copy_dir_recursive(&companion, &target_dir.join(&session.id))?;
+        }
+    }
+    Ok(())
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let dest_path = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_recursive(&entry.path(), &dest_path)?;
+        } else {
+            fs::copy(entry.path(), &dest_path)?;
+        }
+    }
+    Ok(())
 }
 
 fn mtime_iso(path: &Path) -> Option<String> {
@@ -258,11 +318,13 @@ pub fn load_claude_sessions() -> Vec<Session> {
                     }
                     let iso = mtime_iso(&path).unwrap_or_default();
                     let date = mtime_date(&path).unwrap_or_default();
-                    let project = dir
-                        .file_name()
-                        .unwrap_or_default()
-                        .to_string_lossy()
-                        .replace('-', "/");
+                    let project = read_cwd_from_jsonl(&path)
+                        .unwrap_or_else(|| {
+                            dir.file_name()
+                                .unwrap_or_default()
+                                .to_string_lossy()
+                                .replace('-', "/")
+                        });
                     let first = claude_first_prompt(&path);
                     sessions.push(Session {
                         source: "claude".into(),

--- a/src/session.rs
+++ b/src/session.rs
@@ -138,9 +138,13 @@ pub fn copy_session_to_dir(session: &Session, target_dir: &Path) -> std::io::Res
     fs::create_dir_all(target_dir)?;
 
     let src = Path::new(&session.file);
-    if let Some(filename) = src.file_name() {
-        fs::copy(src, target_dir.join(filename))?;
-    }
+    let filename = src.file_name().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("session file path '{}' has no filename", session.file),
+        )
+    })?;
+    fs::copy(src, target_dir.join(filename))?;
 
     if let Some(parent) = src.parent() {
         let companion = parent.join(&session.id);


### PR DESCRIPTION
## Summary

### Bug fixes
- **Fix sig_matches over-counting** in `query_similarity` — was incrementing inside the inner loop for every matching word, not just the best match
- **Add 3 missing semantic boost arms** — `"optimization"`, `"file_operations"`, `"tool_usage"` were generated by `semantic_boosts()` but silently dropped in the match block
- **Guard snippet_around_match against panic** — word-boundary adjustments could push `start` past `end`, causing a slice panic
- **Fix Cursor session dedup** — `fs::read_dir` order isn't guaranteed; two-pass approach eliminates duplicate sessions
- **Deduplicate errors in inspect output** — same error no longer appears multiple times
- **Make `-k`/`--keyword` global** — now works after subcommand name (`ch search "query" -k react`)
- **Fall back to first_prompt in deep search results** — no more empty title when session has no summary
- **Lower noise threshold** from 40 to 10 chars — short messages like "rebuild docker" are now searchable

### Improvements
- **Read `cwd` from JSONL for accurate project paths** — the naive `replace('-', '/')` on directory names produced wrong paths for projects with dashes (e.g., `chat-history` → `chat/history`). Now reads the `cwd` field from JSONL as the primary source. Inspired by [raine/claude-history](https://github.com/raine/claude-history).
- **Copy session files on resume when project dir is gone** — when the original project directory no longer exists, copies the session to the current directory's Claude project folder and resumes from CWD. Solves the [claude-code#5768](https://github.com/anthropics/claude-code/issues/5768) limitation. Approach from [raine/claude-history](https://github.com/raine/claude-history).
- **Cache `is_color()` in a LazyLock** — avoids repeated `is_terminal()` + `env::var()` syscalls per ANSI code

## Test plan
- [x] `cargo build --release` compiles clean
- [x] 56/56 regression tests pass (list, search, inspect, view, export, find, resume, edge cases)
- [x] `--project chat-history` now matches correctly (was broken with naive decode)
- [x] All 4 real project directories round-trip through encode/decode correctly
- [x] `ch search "optimize file" --deep` — optimization/file boosts now reflected in scores
- [x] `ch search "how do I fix auth errors" --scope similar` — similar scope works with corrected sig_matches
- [x] `ch search "docker" -k rust` — keyword flag works after subcommand
- [x] `ch search "rebuild docker" --deep` — short messages (14 chars) now searchable