### PR TITLE
Fix --project matching for Cursor-encoded project paths

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -134,6 +134,13 @@ pub fn encode_path_for_claude(path: &Path) -> String {
     path.to_string_lossy().replace('/', "-")
 }
 
+fn normalize_for_project_match(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '-' { c } else { '-' })
+        .collect::<String>()
+        .to_lowercase()
+}
+
 pub fn copy_session_to_dir(session: &Session, target_dir: &Path) -> std::io::Result<()> {
     fs::create_dir_all(target_dir)?;
 
@@ -830,7 +837,8 @@ pub fn filter_sessions(
                 return false;
             }
             if let Some(proj) = project
-                && !s.project.to_lowercase().contains(&proj.to_lowercase())
+                && !normalize_for_project_match(&s.project)
+                    .contains(&normalize_for_project_match(proj))
             {
                 return false;
             }
@@ -980,6 +988,21 @@ mod tests {
         let filtered = filter_sessions(&sessions, None, None, None, None, Some("chat"), None);
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].project, "chat-history");
+    }
+
+    #[test]
+    fn filter_by_project_underscore_dash_mismatch() {
+        let sessions = vec![make_session(
+            "1",
+            "2025-01-01",
+            "cursor",
+            "codemill-bhardayu-macro-mt-21188",
+            "",
+            "s1",
+        )];
+        let filtered =
+            filter_sessions(&sessions, None, None, None, None, Some("macro_mt_21188"), None);
+        assert_eq!(filtered.len(), 1, "underscore in filter should match dashes in project path");
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -137,7 +137,7 @@ pub fn encode_path_for_claude(path: &Path) -> String {
 fn normalize_for_project_match(s: &str) -> String {
     s.chars()
         .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' {
+            if c.is_alphanumeric() || c == '-' {
                 c
             } else {
                 '-'
@@ -817,6 +817,7 @@ pub fn filter_sessions(
     project: Option<&str>,
     branch: Option<&str>,
 ) -> Vec<Session> {
+    let project_norm = project.map(normalize_for_project_match);
     let mut out: Vec<Session> = sessions
         .iter()
         .filter(|s| {
@@ -842,9 +843,8 @@ pub fn filter_sessions(
             {
                 return false;
             }
-            if let Some(proj) = project
-                && !normalize_for_project_match(&s.project)
-                    .contains(&normalize_for_project_match(proj))
+            if let Some(proj_norm) = project_norm.as_ref()
+                && !normalize_for_project_match(&s.project).contains(proj_norm)
             {
                 return false;
             }

--- a/src/session.rs
+++ b/src/session.rs
@@ -136,7 +136,13 @@ pub fn encode_path_for_claude(path: &Path) -> String {
 
 fn normalize_for_project_match(s: &str) -> String {
     s.chars()
-        .map(|c| if c.is_ascii_alphanumeric() || c == '-' { c } else { '-' })
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
         .collect::<String>()
         .to_lowercase()
 }
@@ -996,13 +1002,24 @@ mod tests {
             "1",
             "2025-01-01",
             "cursor",
-            "codemill-bhardayu-macro-mt-21188",
+            "proj-one-two-123",
             "",
-            "s1",
+            "",
         )];
-        let filtered =
-            filter_sessions(&sessions, None, None, None, None, Some("macro_mt_21188"), None);
-        assert_eq!(filtered.len(), 1, "underscore in filter should match dashes in project path");
+        let filtered = filter_sessions(
+            &sessions,
+            None,
+            None,
+            None,
+            None,
+            Some("proj_one_two_123"),
+            None,
+        );
+        assert_eq!(
+            filtered.len(),
+            1,
+            "underscore in filter should match dashes in project path"
+        );
     }
 
     #[test]


### PR DESCRIPTION
This fixes / filtering when Cursor encodes projects differently (e.g. underscores vs dashes). We normalize punctuation during project matching so users can reliably filter sessions by project path substring.

Test:
- 
running 41 tests
test find_missing_session ... ok
test filter_by_branch_flag ... ok
test date_filter ... ok
test filter_by_source_flag ... ok
test cursor_session_view ... ok
test export_preserves_all_messages ... ok
test cursor_sessions_listed ... ok
test help_output ... ok
test find_session_prints_path ... ok
test deep_search_with_transcript ... ok
test cursor_session_deep_search ... ok
test export_creates_file ... ok
test deep_search_finds_tool_output_content ... ok
test inspect_missing_session ... ok
test inspect_last_session ... ok
test inspect_session_with_transcript ... ok
test inspect_shows_model_and_tokens ... ok
test install_skill_creates_files ... ok
test deep_search_json_combined ... ok
test inspect_shows_tools_and_files ... ok
test keyword_filter_global ... ok
test inspect_shows_accomplishments_and_decisions ... ok
test list_shows_fixture_sessions ... ok
test no_sessions_shows_empty ... ok
test list_summarize_groups_by_day ... ok
test no_color_env_disables_colors ... ok
test list_verbose_shows_ids ... ok
test malformed_jsonl_handled_gracefully ... ok
test search_json_empty ... ok
test search_index_finds_session ... ok
test mixed_sources_both_listed ... ok
test summarize_empty ... ok
test search_no_results ... ok
test view_missing_session ... ok
test search_json_format ... ok
test search_by_uuid ... ok
test keyword_filter_with_search ... ok
test view_last_session ... ok
test view_plain_output ... ok
test view_with_tools_flag ... ok
test view_session_with_transcript ... ok

test result: ok. 41 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.39s

