### PR TITLE
Deduplicate timestamp parsing and fix bare timestamp recency bug

### DIFF
--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -1,5 +1,4 @@
 use crate::session::*;
-use chrono::{DateTime, FixedOffset};
 use std::collections::{BTreeSet, HashSet};
 
 pub struct InspectInfo {
@@ -161,12 +160,7 @@ pub fn inspect_session(session: &Session) -> Option<InspectInfo> {
     let duration = if timestamps.len() >= 2 {
         let min_ts = timestamps.iter().min().unwrap();
         let max_ts = timestamps.iter().max().unwrap();
-        let parse_ts = |s: &str| -> Option<DateTime<FixedOffset>> {
-            let s = s.replace('Z', "+00:00");
-            DateTime::parse_from_rfc3339(&s)
-                .ok()
-                .or_else(|| DateTime::parse_from_str(&s, "%Y-%m-%dT%H:%M:%S%.f%:z").ok())
-        };
+        let parse_ts = crate::session::parse_any_timestamp;
         match (parse_ts(min_ts), parse_ts(max_ts)) {
             (Some(t1), Some(t2)) => (t2 - t1).num_minutes(),
             _ => 0,

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, FixedOffset, Local, Utc};
+use chrono::Local;
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
@@ -242,18 +242,8 @@ pub fn recency_multiplier(timestamp_str: &str) -> f64 {
     if timestamp_str.is_empty() {
         return 1.0;
     }
-    let ts_str = timestamp_str.replace('Z', "+00:00");
-    let ts = match DateTime::<FixedOffset>::parse_from_rfc3339(&ts_str) {
-        Ok(t) => t,
-        Err(_) => {
-            if let Ok(t) = DateTime::parse_from_str(&ts_str, "%Y-%m-%dT%H:%M:%S%.f%:z") {
-                t
-            } else if let Ok(t) = ts_str.parse::<DateTime<Utc>>() {
-                t.fixed_offset()
-            } else {
-                return 1.0;
-            }
-        }
+    let Some(ts) = crate::session::parse_any_timestamp(timestamp_str) else {
+        return 1.0;
     };
     let now = Local::now().fixed_offset();
     let age = now.signed_duration_since(ts);

--- a/src/search.rs
+++ b/src/search.rs
@@ -143,11 +143,7 @@ fn parse_timeframe_duration(tf: &str) -> chrono::Duration {
 }
 
 fn parse_timestamp(ts: &str) -> Option<DateTime<FixedOffset>> {
-    let s = ts.replace('Z', "+00:00");
-    DateTime::parse_from_rfc3339(&s)
-        .or_else(|_| DateTime::parse_from_str(&s, "%Y-%m-%dT%H:%M:%S%.f%:z"))
-        .ok()
-        .or_else(|| s.parse::<DateTime<Utc>>().ok().map(|t| t.fixed_offset()))
+    crate::session::parse_any_timestamp(ts)
 }
 
 pub fn scored_search(

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,5 +1,5 @@
 use crate::parser::{clean_prompt, extract_text, is_clear_metadata, is_warmup_message};
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, FixedOffset, NaiveDate, Utc};
 use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashSet;
@@ -187,7 +187,15 @@ fn mtime_iso(path: &Path) -> Option<String> {
     let mtime = meta.modified().ok()?;
     let dur = mtime.duration_since(SystemTime::UNIX_EPOCH).ok()?;
     let dt = DateTime::<Utc>::from_timestamp(dur.as_secs() as i64, 0)?;
-    Some(dt.format("%Y-%m-%dT%H:%M:%S").to_string())
+    Some(dt.format("%Y-%m-%dT%H:%M:%SZ").to_string())
+}
+
+pub fn parse_any_timestamp(s: &str) -> Option<DateTime<FixedOffset>> {
+    let s = s.replace('Z', "+00:00");
+    DateTime::parse_from_rfc3339(&s)
+        .or_else(|_| DateTime::parse_from_str(&s, "%Y-%m-%dT%H:%M:%S%.f%:z"))
+        .ok()
+        .or_else(|| s.parse::<DateTime<Utc>>().ok().map(|t| t.fixed_offset()))
 }
 
 fn mtime_date(path: &Path) -> Option<String> {
@@ -1250,5 +1258,29 @@ mod tests {
         let data = r#"{"type":"user","message":{"content":"hello"}}"#;
         std::fs::write(tmp.path(), data).unwrap();
         assert_eq!(read_cwd_from_jsonl(tmp.path()), None);
+    }
+
+    #[test]
+    fn parse_any_timestamp_rfc3339() {
+        assert!(parse_any_timestamp("2025-01-15T10:30:00+00:00").is_some());
+    }
+
+    #[test]
+    fn parse_any_timestamp_z_suffix() {
+        assert!(parse_any_timestamp("2025-01-15T10:30:00Z").is_some());
+    }
+
+    #[test]
+    fn parse_any_timestamp_invalid() {
+        assert!(parse_any_timestamp("not-a-date").is_none());
+        assert!(parse_any_timestamp("").is_none());
+    }
+
+    #[test]
+    fn mtime_iso_appends_z() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let ts = mtime_iso(tmp.path()).unwrap();
+        assert!(ts.ends_with('Z'), "mtime_iso should produce Z-suffixed timestamps, got: {ts}");
+        assert!(parse_any_timestamp(&ts).is_some(), "mtime_iso output should be parseable");
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -1280,7 +1280,13 @@ mod tests {
     fn mtime_iso_appends_z() {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let ts = mtime_iso(tmp.path()).unwrap();
-        assert!(ts.ends_with('Z'), "mtime_iso should produce Z-suffixed timestamps, got: {ts}");
-        assert!(parse_any_timestamp(&ts).is_some(), "mtime_iso output should be parseable");
+        assert!(
+            ts.ends_with('Z'),
+            "mtime_iso should produce Z-suffixed timestamps, got: {ts}"
+        );
+        assert!(
+            parse_any_timestamp(&ts).is_some(),
+            "mtime_iso output should be parseable"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Extract shared `parse_any_timestamp` in `session.rs`, replacing three near-identical inline parsers in `scoring.rs`, `search.rs`, and `inspect.rs`
- Fix `mtime_iso` to append `Z` suffix — bare timestamps without timezone caused orphan JSONL and Cursor sessions to always get recency multiplier 1.0, systematically ranking them below indexed Claude sessions
- `inspect.rs` was also missing the third generic-parse fallback, so some timestamps failed to parse during inspect

## Test plan
- [x] All 153 existing tests pass (112 unit + 41 integration)
- [x] New unit tests for `parse_any_timestamp` (RFC3339, Z-suffix, invalid inputs)
- [x] New unit test verifying `mtime_iso` output ends with `Z` and is parseable
- [x] Manually verified with `ch search`, `ch inspect --last`, `ch --source cursor`, `ch -L`