### PR TITLE
Exclude empty-timestamp messages when timeframe filter is active

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -261,8 +261,10 @@ pub fn scored_search(
                     continue;
                 }
 
+                if tf_cutoff.is_some() && msg.timestamp.is_empty() {
+                    continue;
+                }
                 if let Some(cutoff) = tf_cutoff
-                    && !msg.timestamp.is_empty()
                     && let Some(ts) = parse_timestamp(&msg.timestamp)
                     && ts < cutoff
                 {


### PR DESCRIPTION
Fixes `--timeframe today` including undated Cursor messages because the empty-timestamp guard was inside the AND chain, causing those messages to skip the cutoff check entirely. Now messages with empty timestamps are excluded when any timeframe filter is active.

Test:
- All 149 existing tests pass
- Manually verified `ch search "authentication" --timeframe today` only returns dated results