### PR TITLE
Fix --local flag being silently ignored for search subcommand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -165,6 +165,14 @@ fn main() {
     let from_d = parse_date_arg(&cli.from_date);
     let to_d = parse_date_arg(&cli.to_date);
 
+    let project_filter = if cli.local && cli.project.is_none() {
+        std::env::current_dir()
+            .ok()
+            .and_then(|cwd| cwd.file_name().map(|n| n.to_string_lossy().to_string()))
+    } else {
+        cli.project.clone()
+    };
+
     match cli.command {
         Some(Commands::Search {
             query,
@@ -180,7 +188,7 @@ fn main() {
                 to_d,
                 cli.keyword.as_deref(),
                 cli.source.as_deref(),
-                cli.project.as_deref(),
+                project_filter.as_deref(),
                 cli.branch.as_deref(),
             );
 
@@ -336,13 +344,6 @@ fn main() {
         }
         Some(Commands::InstallSkill) => unreachable!(),
         None => {
-            let mut project_filter = cli.project.as_deref().map(String::from);
-            if cli.local
-                && project_filter.is_none()
-                && let Ok(cwd) = std::env::current_dir()
-            {
-                project_filter = cwd.file_name().map(|n| n.to_string_lossy().to_string());
-            }
             let filtered = filter_sessions(
                 &sessions,
                 from_d,


### PR DESCRIPTION
Hoists the `--local` / `-L` project filter logic before the match statement so it applies to both `search` and the default list command. Previously it only fired in the list (None) branch, so `ch -L search "query"` silently ignored the flag.

## Test plan
- [x] All 149 existing tests pass
- [x] Manually verified `ch -L search "deploy"` filters to current project only
- [x] Manually verified `ch search "deploy"` without `-L` returns cross-project results
- [ ] Add CLI regression test for `-L` with search subcommand