### PR TITLE
Add OpenAI Codex CLI as a conversation history source

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ chat-history view --last --plain           # plain text (pipe-friendly)
 
 ```bash
 chat-history export 2df5 -o session.md     # export as markdown
-chat-history resume 2df5                   # resume Claude Code session
+chat-history resume 2df5                   # resume Claude Code or Codex session
 chat-history find e912                     # print file path (for scripting)
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # chat-history
 
-A fast Rust CLI to search, inspect, and export **Claude Code** and **Cursor** conversation history.
+A fast Rust CLI to search, inspect, and export **Claude Code**, **Cursor**, and **OpenAI Codex CLI** conversation history.
 
 Scoring logic ported from [claude-historian-mcp](https://github.com/Vvkmnn/claude-historian-mcp), [claude-history](https://github.com/raine/claude-history), and [search-sessions](https://github.com/sinzin91/search-sessions), with Cursor transcript parsing inspired by [cursor-history](https://github.com/S2thend/cursor-history).
 
@@ -20,7 +20,7 @@ This installs both `chat-history` and `ch` (short alias) into `~/.cargo/bin/`.
 chat-history install-skill
 ```
 
-This writes the bundled `SKILL.md` to `~/.cursor/skills/chat-history/` and `~/.claude/skills/chat-history/`, giving Claude Code and Cursor agents the ability to search your conversation history automatically. Re-run after upgrading to pick up skill updates.
+This writes the bundled `SKILL.md` to `~/.cursor/skills/chat-history/`, `~/.claude/skills/chat-history/`, and `~/.codex/skills/chat-history/`, giving Claude Code, Cursor, and Codex agents the ability to search your conversation history automatically. Re-run after upgrading to pick up skill updates.
 
 ### Build from source
 
@@ -57,6 +57,7 @@ chat-history                               # all sessions
 chat-history -L                            # current workspace only
 chat-history --source claude               # Claude Code sessions only
 chat-history --source cursor               # Cursor sessions only
+chat-history --source codex                # Codex sessions only
 chat-history --from 2026-03-01 --to 2026-03-20
 chat-history --from yesterday              # natural language dates
 chat-history --from "3 days ago"           # relative dates
@@ -120,7 +121,7 @@ chat-history find e912                     # print file path (for scripting)
 ### Install agent skill
 
 ```bash
-chat-history install-skill                 # installs SKILL.md for Claude Code + Cursor
+chat-history install-skill                 # installs SKILL.md for Claude Code + Cursor + Codex
 ```
 
 ## Data sources
@@ -130,6 +131,7 @@ chat-history install-skill                 # installs SKILL.md for Claude Code +
 | Claude Code index | `~/.claude/projects/*/sessions-index.json` | Summary, dates, branch, message count |
 | Claude Code JSONL | `~/.claude/projects/*/*.jsonl` | Full conversations with tool calls |
 | Cursor agent transcripts | `~/.cursor/projects/*/agent-transcripts/` | JSONL or plain-text transcripts |
+| Codex CLI rollouts | `~/.codex/sessions/*/rollout-*.jsonl` | Full conversations with tool calls (honors `$CODEX_HOME`) |
 
 ## Search scoring
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -51,7 +51,7 @@ chat-history inspect <partial-uuid>
 chat-history view --last --plain           # pipe-friendly plain text
 chat-history view <id> --tools             # show tool call names
 chat-history export <id> -o session.md     # export as markdown
-chat-history resume <id>                   # resume Claude Code session
+chat-history resume <id>                   # resume Claude Code or Codex session
 chat-history find <id>                     # print file path for scripting
 ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: chat-history
-description: Search, inspect, and export Claude Code and Cursor conversation history. Use when the user asks about past conversations, wants to find a previous session, needs to search chat history, wants a summary of what they worked on, or asks to resume a session. Also use when the user says "what did I work on", "find that conversation where I...", "show me my recent sessions", or "search my history for...".
+description: Search, inspect, and export Claude Code, Cursor, and Codex conversation history. Use when the user asks about past conversations, wants to find a previous session, needs to search chat history, wants a summary of what they worked on, or asks to resume a session. Also use when the user says "what did I work on", "find that conversation where I...", "show me my recent sessions", or "search my history for...".
 ---
 
 # chat-history
@@ -32,6 +32,7 @@ chat-history --from yesterday -s           # grouped by day
 chat-history --from "3 days ago"           # natural language dates
 chat-history --source claude               # Claude Code only
 chat-history --source cursor               # Cursor only
+chat-history --source codex                # Codex only
 chat-history -L                            # current workspace only
 chat-history --branch feature-xyz          # filter by branch
 chat-history -k "auth" -v                  # keyword filter, show IDs

--- a/src/display.rs
+++ b/src/display.rs
@@ -23,6 +23,7 @@ macro_rules! c {
                 "blue" => "\x1b[34m",
                 "red" => "\x1b[31m",
                 "bg_blue" => "\x1b[44m",
+                "bg_magenta" => "\x1b[45m",
                 "bg_cyan" => "\x1b[46m",
                 _ => "",
             }
@@ -33,10 +34,10 @@ macro_rules! c {
 }
 
 fn src_tag(source: &str) -> String {
-    if source == "claude" {
-        format!("{}{} CC {}", c!("bg_cyan"), c!("bold"), c!("reset"))
-    } else {
-        format!("{}{} CR {}", c!("bg_blue"), c!("bold"), c!("reset"))
+    match source {
+        "claude" => format!("{}{} CC {}", c!("bg_cyan"), c!("bold"), c!("reset")),
+        "codex" => format!("{}{} CX {}", c!("bg_magenta"), c!("bold"), c!("reset")),
+        _ => format!("{}{} CR {}", c!("bg_blue"), c!("bold"), c!("reset")),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -290,8 +290,8 @@ fn main() {
                 eprintln!("Session not found: {session_id}");
                 std::process::exit(1);
             };
-            if session.source != "claude" {
-                eprintln!("Resume is only supported for Claude Code sessions.");
+            if session.source != "claude" && session.source != "codex" {
+                eprintln!("Resume is only supported for Claude Code and Codex sessions.");
                 std::process::exit(1);
             }
             println!(
@@ -308,7 +308,7 @@ fn main() {
                     if let Err(e) = std::env::set_current_dir(project) {
                         eprintln!("Warning: could not cd to {}: {e}", session.project);
                     }
-                } else {
+                } else if session.source == "claude" {
                     eprintln!(
                         "Project dir {} no longer exists, copying session to current directory...",
                         session.project
@@ -330,10 +330,13 @@ fn main() {
                 }
             }
             use std::os::unix::process::CommandExt;
-            let err = std::process::Command::new("claude")
-                .args(["--resume", &session.id])
-                .exec();
-            eprintln!("Failed to exec claude: {err}");
+            let (bin, args) = if session.source == "codex" {
+                ("codex", ["resume", session.id.as_str()])
+            } else {
+                ("claude", ["--resume", session.id.as_str()])
+            };
+            let err = std::process::Command::new(bin).args(args).exec();
+            eprintln!("Failed to exec {bin}: {err}");
             std::process::exit(1);
         }
         Some(Commands::Find { session_id }) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use clap::{Parser, Subcommand};
 #[derive(Parser)]
 #[command(
     name = "chat-history",
-    about = "Search Claude Code + Cursor conversation history",
+    about = "Search Claude Code + Cursor + Codex conversation history",
     version
 )]
 struct Cli {
@@ -25,7 +25,7 @@ struct Cli {
     #[arg(long = "to", global = true, help = "End date")]
     to_date: Option<String>,
 
-    #[arg(long, global = true, help = "Filter by source (claude/cursor)")]
+    #[arg(long, global = true, help = "Filter by source (claude/cursor/codex)")]
     source: Option<String>,
 
     #[arg(long, global = true, help = "Filter by project path substring")]
@@ -91,7 +91,7 @@ enum Commands {
     Find {
         session_id: String,
     },
-    /// Install the agent skill for Claude Code and Cursor
+    /// Install the agent skill for Claude Code, Cursor, and Codex
     #[command(name = "install-skill")]
     InstallSkill,
 }
@@ -106,6 +106,7 @@ fn skill_targets() -> Vec<(std::path::PathBuf, &'static str)> {
     vec![
         (home.join(".cursor/skills/chat-history"), "Cursor"),
         (home.join(".claude/skills/chat-history"), "Claude Code"),
+        (session::codex_home().join("skills/chat-history"), "Codex"),
     ]
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -68,7 +68,8 @@ pub fn extract_text(content: &Value) -> String {
             for block in arr {
                 let btype = block.get("type").and_then(Value::as_str).unwrap_or("");
                 match btype {
-                    "text" => {
+                    // "input_text"/"output_text" are Codex content block types
+                    "text" | "input_text" | "output_text" => {
                         if let Some(t) = block.get("text").and_then(Value::as_str) {
                             parts.push(t.to_string());
                         }

--- a/src/session.rs
+++ b/src/session.rs
@@ -105,6 +105,17 @@ fn cursor_projects_dir() -> PathBuf {
     home_dir().join(".cursor").join("projects")
 }
 
+pub fn codex_home() -> PathBuf {
+    if let Some(dir) = std::env::var_os("CODEX_HOME") {
+        return PathBuf::from(dir);
+    }
+    home_dir().join(".codex")
+}
+
+fn codex_sessions_dir() -> PathBuf {
+    codex_home().join("sessions")
+}
+
 fn read_cwd_from_jsonl(path: &Path) -> Option<String> {
     let file = fs::File::open(path).ok()?;
     let reader = BufReader::new(file);
@@ -470,9 +481,144 @@ pub fn load_cursor_sessions() -> Vec<Session> {
     sessions
 }
 
+struct CodexMeta {
+    id: String,
+    created: String,
+    cwd: String,
+    branch: String,
+    is_subagent: bool,
+}
+
+// Codex rollout lines are {"timestamp", "type", "payload": {...}}; older CLI
+// versions wrote the payload fields at the top level without a wrapper.
+fn codex_payload(entry: &Value) -> &Value {
+    entry.get("payload").unwrap_or(entry)
+}
+
+fn read_codex_meta(path: &Path) -> Option<CodexMeta> {
+    let file = fs::File::open(path).ok()?;
+    let reader = BufReader::new(file);
+    let line = reader.lines().next()?.ok()?;
+    let entry: Value = serde_json::from_str(line.trim()).ok()?;
+    let payload = codex_payload(&entry);
+    let id = payload.get("id").and_then(Value::as_str)?.to_string();
+    let created = payload
+        .get("timestamp")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let cwd = payload
+        .get("cwd")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let branch = payload
+        .get("git")
+        .and_then(|g| g.get("branch"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let is_subagent = payload
+        .get("source")
+        .and_then(|s| s.get("subagent"))
+        .is_some();
+    Some(CodexMeta {
+        id,
+        created,
+        cwd,
+        branch,
+        is_subagent,
+    })
+}
+
+// Codex injects environment/permission wrappers as user-role messages.
+fn is_codex_noise(text: &str) -> bool {
+    let t = text.trim_start();
+    t.starts_with("<environment_context>")
+        || t.starts_with("<permissions")
+        || t.starts_with("<user_instructions>")
+}
+
+fn codex_first_prompt(path: &Path) -> String {
+    let file = match fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return String::new(),
+    };
+    let reader = BufReader::new(file);
+    for line in reader.lines().take(100) {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        let entry: Value = match serde_json::from_str(line.trim()) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let payload = codex_payload(&entry);
+        if payload.get("type").and_then(Value::as_str) != Some("message")
+            || payload.get("role").and_then(Value::as_str) != Some("user")
+        {
+            continue;
+        }
+        let content = payload
+            .get("content")
+            .cloned()
+            .unwrap_or(Value::String(String::new()));
+        let text = extract_text(&content);
+        let trimmed = text.trim();
+        if !trimmed.is_empty() && !is_codex_noise(trimmed) {
+            return trimmed.chars().take(300).collect();
+        }
+    }
+    String::new()
+}
+
+pub fn load_codex_sessions() -> Vec<Session> {
+    let base = codex_sessions_dir();
+    if !base.exists() {
+        return Vec::new();
+    }
+    let mut sessions = Vec::new();
+    for path in glob::glob(&format!("{}/**/rollout-*.jsonl", base.display()))
+        .into_iter()
+        .flatten()
+        .flatten()
+    {
+        let Some(meta) = read_codex_meta(&path) else {
+            continue;
+        };
+        if meta.is_subagent {
+            continue;
+        }
+        let modified = mtime_iso(&path).unwrap_or_default();
+        let date = meta
+            .created
+            .get(..10)
+            .map(str::to_string)
+            .unwrap_or_else(|| mtime_date(&path).unwrap_or_default());
+        let first = codex_first_prompt(&path);
+        sessions.push(Session {
+            source: "codex".into(),
+            id: meta.id,
+            summary: String::new(),
+            first_prompt: first,
+            created: meta.created,
+            modified,
+            date,
+            messages: 0,
+            branch: meta.branch,
+            project: meta.cwd,
+            file: path.to_string_lossy().to_string(),
+            is_sidechain: false,
+        });
+    }
+    sessions
+}
+
 pub fn load_all_sessions() -> Vec<Session> {
     let mut all = load_claude_sessions();
     all.extend(load_cursor_sessions());
+    all.extend(load_codex_sessions());
     all
 }
 
@@ -657,6 +803,100 @@ pub fn parse_claude_jsonl(
     (messages, None)
 }
 
+pub fn parse_codex_jsonl(filepath: &str) -> Vec<Message> {
+    let file = match fs::File::open(filepath) {
+        Ok(f) => f,
+        Err(_) => return Vec::new(),
+    };
+    let reader = BufReader::new(file);
+    let mut messages: Vec<Message> = Vec::new();
+    let mut session_id = String::new();
+    let mut project_path = String::new();
+    let mut total_chars: usize = 0;
+    let max_chars: usize = 4 * 1024 * 1024;
+
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let entry: Value = match serde_json::from_str(trimmed) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if entry.get("type").and_then(Value::as_str) == Some("session_meta") {
+            if let Some(p) = entry.get("payload") {
+                session_id = p
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                project_path = p
+                    .get("cwd")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+            }
+            continue;
+        }
+        let timestamp = entry
+            .get("timestamp")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        let payload = codex_payload(&entry);
+        match payload.get("type").and_then(Value::as_str) {
+            Some("message") => {
+                let role = payload.get("role").and_then(Value::as_str).unwrap_or("");
+                if role != "user" && role != "assistant" {
+                    continue;
+                }
+                let content_raw = payload
+                    .get("content")
+                    .cloned()
+                    .unwrap_or(Value::String(String::new()));
+                let text = extract_text(&content_raw);
+                if text.trim().is_empty() || (role == "user" && is_codex_noise(&text)) {
+                    continue;
+                }
+                let ctx = crate::parser::extract_context(&content_raw);
+                if total_chars < max_chars {
+                    total_chars += text.len();
+                    messages.push(Message {
+                        uuid: String::new(),
+                        timestamp,
+                        role: role.to_string(),
+                        content: text,
+                        session_id: session_id.clone(),
+                        project_path: project_path.clone(),
+                        tool_uses: ctx.tools,
+                        files_referenced: ctx.files,
+                        error_patterns: ctx.errors,
+                        relevance_score: 0.0,
+                        final_score: 0.0,
+                    });
+                }
+            }
+            // Tool calls are separate records in Codex rollouts; attach the
+            // tool name to the assistant message that initiated it.
+            Some("function_call") => {
+                if let Some(name) = payload.get("name").and_then(Value::as_str)
+                    && let Some(last) = messages.last_mut()
+                    && last.role == "assistant"
+                {
+                    last.tool_uses.push(name.to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+    messages
+}
+
 pub fn parse_cursor_jsonl(filepath: &str) -> Vec<Message> {
     let file = match fs::File::open(filepath) {
         Ok(f) => f,
@@ -791,6 +1031,21 @@ pub fn parse_cursor_txt(filepath: &str) -> Vec<Message> {
 pub fn parse_session(session: &Session, extract_meta: bool) -> (Vec<Message>, Option<SessionMeta>) {
     if session.source == "claude" {
         return parse_claude_jsonl(&session.file, extract_meta);
+    }
+    if session.source == "codex" {
+        let messages = parse_codex_jsonl(&session.file);
+        if extract_meta {
+            return (
+                messages,
+                Some(SessionMeta {
+                    summary: None,
+                    custom_title: None,
+                    model: None,
+                    total_tokens: 0,
+                }),
+            );
+        }
+        return (messages, None);
     }
     let messages = if session.file.ends_with(".jsonl") {
         parse_cursor_jsonl(&session.file)
@@ -1209,6 +1464,92 @@ mod tests {
         assert_eq!(messages[1].role, "assistant");
         assert_eq!(messages[2].role, "user");
         assert_eq!(messages[3].role, "assistant");
+    }
+
+    const CODEX_FIXTURE: &str = r#"{"timestamp":"2026-06-10T10:00:00.000Z","type":"session_meta","payload":{"id":"019e0000-aaaa-bbbb-cccc-000000000001","timestamp":"2026-06-10T10:00:00.000Z","cwd":"/Users/test/myproj","originator":"codex-tui","cli_version":"0.136.0","git":{"commit_hash":"abc123","branch":"feature-codex"}}}
+{"timestamp":"2026-06-10T10:00:01.000Z","type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"<permissions instructions>\nsandbox stuff"}]}}
+{"timestamp":"2026-06-10T10:00:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>\n<cwd>/Users/test/myproj</cwd>\n</environment_context>"}]}}
+{"timestamp":"2026-06-10T10:00:02.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"add connection pooling to the database layer"}]}}
+{"timestamp":"2026-06-10T10:00:05.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"I'll add connection pooling using a bounded pool."}],"phase":"commentary"}}
+{"timestamp":"2026-06-10T10:00:06.000Z","type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{\"command\":[\"ls\"]}","call_id":"call_1"}}
+{"timestamp":"2026-06-10T10:00:07.000Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_1","output":"src tests"}}
+{"timestamp":"2026-06-10T10:00:09.000Z","type":"event_msg","payload":{"type":"token_count","info":{}}}"#;
+
+    #[test]
+    fn parse_codex_jsonl_with_fixture() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), CODEX_FIXTURE).unwrap();
+        let messages = parse_codex_jsonl(tmp.path().to_str().unwrap());
+        assert_eq!(
+            messages.len(),
+            2,
+            "developer and environment_context messages should be filtered"
+        );
+        assert_eq!(messages[0].role, "user");
+        assert_eq!(
+            messages[0].content,
+            "add connection pooling to the database layer"
+        );
+        assert_eq!(
+            messages[0].session_id,
+            "019e0000-aaaa-bbbb-cccc-000000000001"
+        );
+        assert_eq!(messages[0].project_path, "/Users/test/myproj");
+        assert_eq!(messages[0].timestamp, "2026-06-10T10:00:02.000Z");
+        assert_eq!(messages[1].role, "assistant");
+        assert_eq!(
+            messages[1].tool_uses,
+            vec!["shell".to_string()],
+            "function_call tool name should attach to preceding assistant message"
+        );
+    }
+
+    #[test]
+    fn parse_codex_jsonl_legacy_flat_records() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let data = r#"{"id":"legacy-id","timestamp":"2025-08-01T10:00:00.000Z","instructions":null}
+{"type":"message","role":"user","content":[{"type":"input_text","text":"legacy format question"}]}
+{"type":"message","role":"assistant","content":[{"type":"output_text","text":"legacy format answer"}]}"#;
+        std::fs::write(tmp.path(), data).unwrap();
+        let messages = parse_codex_jsonl(tmp.path().to_str().unwrap());
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].content, "legacy format question");
+        assert_eq!(messages[1].content, "legacy format answer");
+    }
+
+    #[test]
+    fn parse_codex_jsonl_nonexistent_file() {
+        assert!(parse_codex_jsonl("/nonexistent/rollout.jsonl").is_empty());
+    }
+
+    #[test]
+    fn codex_first_prompt_skips_noise() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), CODEX_FIXTURE).unwrap();
+        assert_eq!(
+            codex_first_prompt(tmp.path()),
+            "add connection pooling to the database layer"
+        );
+    }
+
+    #[test]
+    fn read_codex_meta_basic() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), CODEX_FIXTURE).unwrap();
+        let meta = read_codex_meta(tmp.path()).unwrap();
+        assert_eq!(meta.id, "019e0000-aaaa-bbbb-cccc-000000000001");
+        assert_eq!(meta.created, "2026-06-10T10:00:00.000Z");
+        assert_eq!(meta.cwd, "/Users/test/myproj");
+        assert_eq!(meta.branch, "feature-codex");
+        assert!(!meta.is_subagent);
+    }
+
+    #[test]
+    fn read_codex_meta_detects_subagent() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let data = r#"{"timestamp":"2026-06-10T10:00:00.000Z","type":"session_meta","payload":{"id":"sub-1","timestamp":"2026-06-10T10:00:00.000Z","cwd":"/p","source":{"subagent":{"parent_thread_id":"parent-1","depth":1}}}}"#;
+        std::fs::write(tmp.path(), data).unwrap();
+        assert!(read_codex_meta(tmp.path()).unwrap().is_subagent);
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -531,12 +531,20 @@ fn read_codex_meta(path: &Path) -> Option<CodexMeta> {
     })
 }
 
-// Codex injects environment/permission wrappers as user-role messages.
+// Codex injects system wrappers (environment, permissions, goal context,
+// aborted-turn markers, subagent notifications) as user-role messages.
 fn is_codex_noise(text: &str) -> bool {
     let t = text.trim_start();
-    t.starts_with("<environment_context>")
-        || t.starts_with("<permissions")
-        || t.starts_with("<user_instructions>")
+    [
+        "<environment_context>",
+        "<permissions",
+        "<user_instructions>",
+        "<turn_aborted",
+        "<goal_context",
+        "<subagent_notification",
+    ]
+    .iter()
+    .any(|tag| t.starts_with(tag))
 }
 
 fn codex_first_prompt(path: &Path) -> String {
@@ -555,18 +563,25 @@ fn codex_first_prompt(path: &Path) -> String {
             Err(_) => continue,
         };
         let payload = codex_payload(&entry);
-        if payload.get("type").and_then(Value::as_str) != Some("message")
-            || payload.get("role").and_then(Value::as_str) != Some("user")
-        {
-            continue;
-        }
-        let content = payload
-            .get("content")
-            .cloned()
-            .unwrap_or(Value::String(String::new()));
-        let text = extract_text(&content);
+        let text = match payload.get("type").and_then(Value::as_str) {
+            Some("message") if payload.get("role").and_then(Value::as_str) == Some("user") => {
+                let content = payload
+                    .get("content")
+                    .cloned()
+                    .unwrap_or(Value::String(String::new()));
+                extract_text(&content)
+            }
+            // event_msg user_message records carry the literal text the user
+            // typed, without Codex's XML wrappers (e.g. <user_action>).
+            Some("user_message") => payload
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string(),
+            _ => continue,
+        };
         let trimmed = text.trim();
-        if !trimmed.is_empty() && !is_codex_noise(trimmed) {
+        if !trimmed.is_empty() && !is_codex_noise(trimmed) && !trimmed.starts_with("<user_action") {
             return trimmed.chars().take(300).collect();
         }
     }
@@ -812,6 +827,9 @@ pub fn parse_codex_jsonl(filepath: &str) -> Vec<Message> {
     let mut messages: Vec<Message> = Vec::new();
     let mut session_id = String::new();
     let mut project_path = String::new();
+    // Tool calls made before the assistant says anything; attached to the
+    // next assistant message so they aren't lost.
+    let mut pending_tools: Vec<String> = Vec::new();
     let mut total_chars: usize = 0;
     let max_chars: usize = 4 * 1024 * 1024;
 
@@ -828,19 +846,20 @@ pub fn parse_codex_jsonl(filepath: &str) -> Vec<Message> {
             Ok(v) => v,
             Err(_) => continue,
         };
-        if entry.get("type").and_then(Value::as_str) == Some("session_meta") {
-            if let Some(p) = entry.get("payload") {
-                session_id = p
-                    .get("id")
-                    .and_then(Value::as_str)
-                    .unwrap_or("")
-                    .to_string();
-                project_path = p
-                    .get("cwd")
-                    .and_then(Value::as_str)
-                    .unwrap_or("")
-                    .to_string();
-            }
+        // session_meta carries id/cwd; legacy files put them flat on line 1.
+        let etype = entry.get("type").and_then(Value::as_str);
+        if etype == Some("session_meta") || (etype.is_none() && entry.get("id").is_some()) {
+            let p = codex_payload(&entry);
+            session_id = p
+                .get("id")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            project_path = p
+                .get("cwd")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
             continue;
         }
         let timestamp = entry
@@ -866,6 +885,10 @@ pub fn parse_codex_jsonl(filepath: &str) -> Vec<Message> {
                 let ctx = crate::parser::extract_context(&content_raw);
                 if total_chars < max_chars {
                     total_chars += text.len();
+                    let mut tool_uses = ctx.tools;
+                    if role == "assistant" {
+                        tool_uses.append(&mut pending_tools);
+                    }
                     messages.push(Message {
                         uuid: String::new(),
                         timestamp,
@@ -873,7 +896,7 @@ pub fn parse_codex_jsonl(filepath: &str) -> Vec<Message> {
                         content: text,
                         session_id: session_id.clone(),
                         project_path: project_path.clone(),
-                        tool_uses: ctx.tools,
+                        tool_uses,
                         files_referenced: ctx.files,
                         error_patterns: ctx.errors,
                         relevance_score: 0.0,
@@ -882,13 +905,16 @@ pub fn parse_codex_jsonl(filepath: &str) -> Vec<Message> {
                 }
             }
             // Tool calls are separate records in Codex rollouts; attach the
-            // tool name to the assistant message that initiated it.
+            // tool name to the assistant message that initiated it, or hold
+            // it for the next assistant message if none exists yet.
             Some("function_call") => {
-                if let Some(name) = payload.get("name").and_then(Value::as_str)
-                    && let Some(last) = messages.last_mut()
-                    && last.role == "assistant"
-                {
-                    last.tool_uses.push(name.to_string());
+                if let Some(name) = payload.get("name").and_then(Value::as_str) {
+                    match messages.last_mut() {
+                        Some(last) if last.role == "assistant" => {
+                            last.tool_uses.push(name.to_string());
+                        }
+                        _ => pending_tools.push(name.to_string()),
+                    }
                 }
             }
             _ => {}
@@ -1515,6 +1541,44 @@ mod tests {
         assert_eq!(messages.len(), 2);
         assert_eq!(messages[0].content, "legacy format question");
         assert_eq!(messages[1].content, "legacy format answer");
+        assert_eq!(
+            messages[0].session_id, "legacy-id",
+            "session id should be read from the legacy flat meta line"
+        );
+    }
+
+    #[test]
+    fn parse_codex_jsonl_attaches_leading_tool_calls_to_next_assistant() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let data = r#"{"timestamp":"2026-06-10T10:00:00.000Z","type":"session_meta","payload":{"id":"s1","timestamp":"2026-06-10T10:00:00.000Z","cwd":"/p"}}
+{"timestamp":"2026-06-10T10:00:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"run the tests"}]}}
+{"timestamp":"2026-06-10T10:00:02.000Z","type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{}","call_id":"c1"}}
+{"timestamp":"2026-06-10T10:00:03.000Z","type":"response_item","payload":{"type":"function_call","name":"read_file","arguments":"{}","call_id":"c2"}}
+{"timestamp":"2026-06-10T10:00:04.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"All tests pass."}]}}"#;
+        std::fs::write(tmp.path(), data).unwrap();
+        let messages = parse_codex_jsonl(tmp.path().to_str().unwrap());
+        assert_eq!(messages.len(), 2);
+        assert_eq!(
+            messages[1].tool_uses,
+            vec!["shell".to_string(), "read_file".to_string()],
+            "tool calls made before any assistant text should attach to the next assistant message"
+        );
+    }
+
+    #[test]
+    fn is_codex_noise_covers_injected_wrappers() {
+        for noise in [
+            "<environment_context>\n<cwd>/p</cwd>",
+            "<permissions instructions>\nsandbox",
+            "<user_instructions>do x</user_instructions>",
+            "<turn_aborted>user interrupted</turn_aborted>",
+            "<goal_context>...</goal_context>",
+            "<subagent_notification>done</subagent_notification>",
+        ] {
+            assert!(is_codex_noise(noise), "should filter: {noise}");
+        }
+        assert!(!is_codex_noise("fix the <div> rendering bug"));
+        assert!(!is_codex_noise("plain user prompt"));
     }
 
     #[test]
@@ -1529,6 +1593,19 @@ mod tests {
         assert_eq!(
             codex_first_prompt(tmp.path()),
             "add connection pooling to the database layer"
+        );
+    }
+
+    #[test]
+    fn codex_first_prompt_prefers_typed_user_message_over_user_action_wrapper() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let data = r#"{"timestamp":"2026-06-10T10:00:00.000Z","type":"session_meta","payload":{"id":"s1","timestamp":"2026-06-10T10:00:00.000Z","cwd":"/p"}}
+{"timestamp":"2026-06-10T10:00:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<user_action>\n<context>User initiated a review task.</context>\n</user_action>"}]}}
+{"timestamp":"2026-06-10T10:00:02.000Z","type":"event_msg","payload":{"type":"user_message","message":"https://github.com/org/repo/pull/31","images":null}}"#;
+        std::fs::write(tmp.path(), data).unwrap();
+        assert_eq!(
+            codex_first_prompt(tmp.path()),
+            "https://github.com/org/repo/pull/31"
         );
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -8,6 +8,7 @@ fn isolated_cmd() -> (Command, TempDir) {
     let mut cmd = Command::cargo_bin("chat-history").unwrap();
     cmd.env("CLAUDE_CONFIG_DIR", tmp.path());
     cmd.env("HOME", tmp.path());
+    cmd.env_remove("CODEX_HOME");
     (cmd, tmp)
 }
 
@@ -88,6 +89,7 @@ fn install_skill_creates_files() {
         .unwrap()
         .arg("install-skill")
         .env("HOME", tmp.path())
+        .env_remove("CODEX_HOME")
         .assert()
         .success()
         .stdout(predicate::str::contains("installed"));
@@ -99,6 +101,11 @@ fn install_skill_creates_files() {
     assert!(
         tmp.path()
             .join(".cursor/skills/chat-history/SKILL.md")
+            .exists()
+    );
+    assert!(
+        tmp.path()
+            .join(".codex/skills/chat-history/SKILL.md")
             .exists()
     );
 }
@@ -850,6 +857,155 @@ fn setup_cursor_fixture(tmp: &TempDir) {
         txt_content,
     )
     .unwrap();
+}
+
+fn setup_codex_fixture(tmp: &TempDir) {
+    let day_dir = tmp
+        .path()
+        .join(".codex")
+        .join("sessions")
+        .join("2026")
+        .join("06")
+        .join("10");
+    fs::create_dir_all(&day_dir).unwrap();
+
+    let session_id = "019e0000-aaaa-bbbb-cccc-000000000001";
+    let rollout = [
+        r#"{"timestamp":"2026-06-10T10:00:00.000Z","type":"session_meta","payload":{"id":"019e0000-aaaa-bbbb-cccc-000000000001","timestamp":"2026-06-10T10:00:00.000Z","cwd":"/Users/test/codexproj","originator":"codex-tui","cli_version":"0.136.0","git":{"commit_hash":"abc123","branch":"codex-branch"}}}"#,
+        r#"{"timestamp":"2026-06-10T10:00:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>\n<cwd>/Users/test/codexproj</cwd>\n</environment_context>"}]}}"#,
+        r#"{"timestamp":"2026-06-10T10:00:02.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"migrate the auth service to async handlers"}]}}"#,
+        r#"{"timestamp":"2026-06-10T10:00:05.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"I migrated the auth service endpoints to async handlers with tokio."}]}}"#,
+    ]
+    .join("\n");
+    fs::write(
+        day_dir.join(format!("rollout-2026-06-10T10-00-00-{session_id}.jsonl")),
+        rollout,
+    )
+    .unwrap();
+
+    // Sub-agent rollout that must be skipped in listings
+    let subagent = [
+        r#"{"timestamp":"2026-06-10T11:00:00.000Z","type":"session_meta","payload":{"id":"019e0000-aaaa-bbbb-cccc-000000000002","timestamp":"2026-06-10T11:00:00.000Z","cwd":"/Users/test/codexproj","source":{"subagent":{"parent_thread_id":"019e0000-aaaa-bbbb-cccc-000000000001","depth":1}}}}"#,
+        r#"{"timestamp":"2026-06-10T11:00:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"subagent task prompt"}]}}"#,
+    ]
+    .join("\n");
+    fs::write(
+        day_dir.join("rollout-2026-06-10T11-00-00-019e0000-aaaa-bbbb-cccc-000000000002.jsonl"),
+        subagent,
+    )
+    .unwrap();
+}
+
+#[test]
+fn codex_sessions_listed() {
+    let tmp = TempDir::new().unwrap();
+    setup_codex_fixture(&tmp);
+    let output = Command::cargo_bin("chat-history")
+        .unwrap()
+        .env("HOME", tmp.path())
+        .env("CLAUDE_CONFIG_DIR", tmp.path())
+        .env_remove("CODEX_HOME")
+        .env("NO_COLOR", "1")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(output.status.success());
+    assert!(
+        stdout.contains("1 sessions"),
+        "should list exactly one codex session (subagent skipped): {stdout}"
+    );
+    assert!(
+        stdout.contains("migrate the auth service"),
+        "should show codex session's first prompt, not env context: {stdout}"
+    );
+}
+
+#[test]
+fn codex_source_filter() {
+    let tmp = TempDir::new().unwrap();
+    setup_codex_fixture(&tmp);
+    setup_cursor_fixture(&tmp);
+    let output = Command::cargo_bin("chat-history")
+        .unwrap()
+        .args(["--source", "codex"])
+        .env("HOME", tmp.path())
+        .env("CLAUDE_CONFIG_DIR", tmp.path())
+        .env_remove("CODEX_HOME")
+        .env("NO_COLOR", "1")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(output.status.success());
+    assert!(
+        stdout.contains("migrate the auth service"),
+        "codex session should be listed: {stdout}"
+    );
+    assert!(
+        !stdout.contains("refactor the database module"),
+        "cursor session should be filtered out: {stdout}"
+    );
+}
+
+#[test]
+fn codex_session_view() {
+    let tmp = TempDir::new().unwrap();
+    setup_codex_fixture(&tmp);
+    let output = Command::cargo_bin("chat-history")
+        .unwrap()
+        .args(["view", "--last", "--plain"])
+        .env("HOME", tmp.path())
+        .env("CLAUDE_CONFIG_DIR", tmp.path())
+        .env_remove("CODEX_HOME")
+        .env("NO_COLOR", "1")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(output.status.success());
+    assert!(
+        stdout.contains("async handlers with tokio"),
+        "should display codex assistant message: {stdout}"
+    );
+    assert!(
+        !stdout.contains("<environment_context>"),
+        "env context noise should not appear in transcript: {stdout}"
+    );
+}
+
+#[test]
+fn codex_session_deep_search() {
+    let tmp = TempDir::new().unwrap();
+    setup_codex_fixture(&tmp);
+    Command::cargo_bin("chat-history")
+        .unwrap()
+        .args(["search", "async handlers", "--deep"])
+        .env("HOME", tmp.path())
+        .env("CLAUDE_CONFIG_DIR", tmp.path())
+        .env_remove("CODEX_HOME")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("async"));
+}
+
+#[test]
+fn codex_home_env_override() {
+    let tmp = TempDir::new().unwrap();
+    setup_codex_fixture(&tmp);
+    let codex_home = tmp.path().join(".codex");
+    let other_home = TempDir::new().unwrap();
+    let output = Command::cargo_bin("chat-history")
+        .unwrap()
+        .env("HOME", other_home.path())
+        .env("CLAUDE_CONFIG_DIR", other_home.path())
+        .env("CODEX_HOME", &codex_home)
+        .env("NO_COLOR", "1")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(output.status.success());
+    assert!(
+        stdout.contains("migrate the auth service"),
+        "CODEX_HOME should override the default ~/.codex location: {stdout}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds **OpenAI Codex CLI** as a third conversation source alongside Claude Code and Cursor. Format verified against real local Codex 0.136.0 data and cross-checked with existing tools in the space ([cass](https://github.com/Dicklesworthstone/coding_agent_session_search), [codex-trace](https://github.com/PixelPaw-Labs/codex-trace), [codex-history-list](https://github.com/shinshin86/codex-history-list)), which all parse the same rollout layout.

### What Codex stores

`$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl` (default `~/.codex`). Each line is `{"timestamp", "type", "payload"}`: a `session_meta` first line (id, cwd, git branch, sub-agent marker), `response_item` messages with `input_text`/`output_text` content blocks, and separate `function_call` records for tool use.

### Changes

- **`load_codex_sessions()`** — discovers rollouts, reads `session_meta` for id/created/project/branch, skips sub-agent rollouts (mirrors how Claude `agent-*` sidechains are skipped). Missing `~/.codex` → zero sessions, so machines without Codex are unaffected.
- **`parse_codex_jsonl()`** — extracts user/assistant messages; filters injected `<environment_context>`/`<permissions>`/`<user_instructions>` noise and developer-role messages; attaches `function_call` tool names to the preceding assistant message so search scoring and `inspect` tool listings work; tolerates flat records from older Codex versions.
- **`extract_text()`** — accepts Codex `input_text`/`output_text` block types (additive).
- **CLI/UX** — `--source codex` filter, new magenta `CX` badge, `install-skill` also writes to `$CODEX_HOME/skills/chat-history/`.
- **Docs** — README and SKILL.md updated.

### Testing

- 7 new unit tests (parsing, noise filtering, tool attachment, legacy fallback, sub-agent detection, missing file)
- 6 new CLI integration tests (listing, source filter, view, deep search, `CODEX_HOME` override, sub-agent skipped; `install-skill` test extended)
- Full suite: 139 lib + 53 CLI tests pass; `cargo clippy` clean for new code
- Smoke-tested against real `~/.codex` data: list/view/inspect/search/export all work; empty-HOME run confirms graceful absence