### PR TITLE
Align history source parsing with current formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chat-history"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "chat-history"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 rust-version = "1.91"
 authors = ["Ayush Bhardwaj"]
-description = "Search, inspect, and export Claude Code + Cursor conversation history"
+description = "Search, inspect, and export Claude Code, Cursor, and Codex conversation history"
 license = "MIT"
 repository = "https://github.com/ay-bh/chat-history"
 readme = "README.md"
-keywords = ["chat-history", "claude-code", "cursor-ide", "conversation", "transcript"]
+keywords = ["chat-history", "claude-code", "cursor-ide", "codex", "conversation", "transcript"]
 categories = ["command-line-utilities", "development-tools"]
 
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ chat-history -s                            # group by day
 
 ### Scored search
 
-By default, search checks session metadata (summary, first prompt, branch) without parsing transcript files. This is fast — sub-second. Weak index results (★ < 5.0) automatically fall through to deep transcript search. Use `--deep` to force full transcript search, or `--scope` for specialized searches.
+By default, search checks session metadata (title/summary, first prompt, branch, project) without parsing full transcript bodies. This is fast — sub-second. Weak index results (★ < 5.0) automatically fall through to deep transcript search. Use `--deep` to force full transcript search, or `--scope` for specialized searches.
 
 ```bash
 # Fast index search (sub-second, checks summary/prompt/branch)
@@ -128,16 +128,17 @@ chat-history install-skill                 # installs SKILL.md for Claude Code +
 
 | Source | Path | What it contains |
 |---|---|---|
-| Claude Code index | `~/.claude/projects/*/sessions-index.json` | Summary, dates, branch, message count |
-| Claude Code JSONL | `~/.claude/projects/*/*.jsonl` | Full conversations with tool calls |
-| Cursor agent transcripts | `~/.cursor/projects/*/agent-transcripts/` | JSONL or plain-text transcripts |
-| Codex CLI rollouts | `~/.codex/sessions/*/rollout-*.jsonl` | Full conversations with tool calls (honors `$CODEX_HOME`) |
+| Claude Code JSONL | `~/.claude/projects/*/*.jsonl` | Full conversations, `ai-title` / `custom-title`, cwd, branch, tool calls |
+| Claude Code legacy index | `~/.claude/projects/*/sessions-index.json` | Optional legacy metadata when present |
+| Cursor agent transcripts | `~/.cursor/projects/*/agent-transcripts/` | JSONL or plain-text parent sessions |
+| Cursor subagent transcripts | `~/.cursor/projects/*/agent-transcripts/*/subagents/*.jsonl` | Subagent sessions discovered separately |
+| Codex CLI rollouts | `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` | Full conversations with tool calls (honors `$CODEX_HOME`) |
 
 ## Search scoring
 
 ### Index search (default)
 
-Searches `sessions-index.json` metadata with field-weighted scoring:
+Searches loaded session metadata with field-weighted scoring. For modern Claude Code installs this metadata is derived directly from JSONL records (`ai-title`, `custom-title`, first prompt, cwd, and `gitBranch`); `sessions-index.json` is used only when present.
 
 - **Summary match** — 3x weight
 - **First prompt match** — 2x weight

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ chat-history --from "last week" --to today
 chat-history --branch feature-xyz          # filter by git branch
 chat-history -k "auth" -v                  # keyword filter, show IDs/paths
 chat-history -s                            # group by day
+chat-history --sidechains                  # include subagent/sidechain sessions
 ```
 
 ### Scored search
@@ -131,7 +132,7 @@ chat-history install-skill                 # installs SKILL.md for Claude Code +
 | Claude Code JSONL | `~/.claude/projects/*/*.jsonl` | Full conversations, `ai-title` / `custom-title`, cwd, branch, tool calls |
 | Claude Code legacy index | `~/.claude/projects/*/sessions-index.json` | Optional legacy metadata when present |
 | Cursor agent transcripts | `~/.cursor/projects/*/agent-transcripts/` | JSONL or plain-text parent sessions |
-| Cursor subagent transcripts | `~/.cursor/projects/*/agent-transcripts/*/subagents/*.jsonl` | Subagent sessions discovered separately |
+| Cursor subagent transcripts | `~/.cursor/projects/*/agent-transcripts/*/subagents/*.jsonl` | Subagent sessions, hidden unless `--sidechains` |
 | Codex CLI rollouts | `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` | Full conversations with tool calls (honors `$CODEX_HOME`) |
 
 ## Search scoring

--- a/SKILL.md
+++ b/SKILL.md
@@ -20,7 +20,7 @@ This installs both `chat-history` and `ch` (short alias) into `~/.cargo/bin/`.
 - User asks about past conversations or sessions
 - User wants to find something they discussed before
 - User needs a summary of recent work / accomplishments
-- User wants to search across all Claude Code or Cursor history
+- User wants to search across Claude Code, Cursor, or Codex history
 - User wants to resume or export a previous session
 
 ## Commands
@@ -70,6 +70,9 @@ The short alias `ch` works identically: `ch search "auth"`, `ch inspect --last`,
 - Score (`★ N.N`) = relevance score (higher = better match)
 - `[summary]`, `[first_prompt]`, `[branch]` = which field matched in index search
 - `inspect` shows: duration, message count, model name, token count, tools used, files touched, accomplishments, key decisions
+- Claude Code titles come from modern `ai-title` / `custom-title` JSONL records when available
+- Cursor subagent transcripts under `agent-transcripts/*/subagents/` are listed as separate Cursor sessions
+- Codex sessions are read from `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-*.jsonl` (or `~/.codex` by default)
 
 ## Date formats accepted
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -71,7 +71,8 @@ The short alias `ch` works identically: `ch search "auth"`, `ch inspect --last`,
 - `[summary]`, `[first_prompt]`, `[branch]` = which field matched in index search
 - `inspect` shows: duration, message count, model name, token count, tools used, files touched, accomplishments, key decisions
 - Claude Code titles come from modern `ai-title` / `custom-title` JSONL records when available
-- Cursor subagent transcripts under `agent-transcripts/*/subagents/` are listed as separate Cursor sessions
+- Cursor subagent transcripts under `agent-transcripts/*/subagents/` are hidden by default; pass `--sidechains` to list them (tagged `[subagent]`)
+- Codex commentary-phase assistant messages are hidden for turns that reached a final answer; interrupted turns keep their commentary
 - Codex sessions are read from `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-*.jsonl` (or `~/.codex` by default)
 
 ## Date formats accepted

--- a/src/display.rs
+++ b/src/display.rs
@@ -69,13 +69,18 @@ pub fn print_list(sessions: &[Session], verbose: bool) {
         } else {
             format!(" {}({}){}", c!("magenta"), s.branch, c!("reset"))
         };
+        let sidechain = if s.is_sidechain {
+            format!(" {}[subagent]{}", c!("dim"), c!("reset"))
+        } else {
+            String::new()
+        };
         let msgs = if s.messages > 0 {
             format!(" {}[{} msgs]{}", c!("dim"), s.messages, c!("reset"))
         } else {
             String::new()
         };
         println!(
-            "  {}{:3}.{} {} {}{}{}  {}{}{}{}{}",
+            "  {}{:3}.{} {} {}{}{}  {}{}{}{}{}{}",
             c!("dim"),
             i + 1,
             c!("reset"),
@@ -86,6 +91,7 @@ pub fn print_list(sessions: &[Session], verbose: bool) {
             c!("bold"),
             summary,
             c!("reset"),
+            sidechain,
             branch,
             msgs
         );

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -55,7 +55,7 @@ fn extract_sentence_around(text: &str, keyword: &str) -> Option<String> {
     let sentence = text[start..end].trim();
     if sentence.len() > 200 {
         let trunc = text.floor_char_boundary(start + 197).min(end);
-        Some(format!("{}...", &text[start..trunc].trim()))
+        Some(format!("{}...", text[start..trunc].trim()))
     } else {
         Some(sentence.to_string())
     }

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -66,12 +66,7 @@ pub fn inspect_session(session: &Session) -> Option<InspectInfo> {
     if messages.is_empty() {
         return None;
     }
-    let meta = meta_opt.unwrap_or(SessionMeta {
-        summary: None,
-        custom_title: None,
-        model: None,
-        total_tokens: 0,
-    });
+    let meta = meta_opt.unwrap_or_default();
 
     let mut tools_used: BTreeSet<String> = BTreeSet::new();
     let mut files_modified: BTreeSet<String> = BTreeSet::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,13 @@ struct Cli {
         help = "Only show sessions from current workspace"
     )]
     local: bool,
+
+    #[arg(
+        long,
+        global = true,
+        help = "Include subagent/sidechain sessions (hidden by default)"
+    )]
+    sidechains: bool,
 }
 
 #[derive(Subcommand)]
@@ -162,7 +169,10 @@ fn main() {
         return;
     }
 
-    let sessions = load_all_sessions();
+    let mut sessions = load_all_sessions();
+    if !cli.sidechains {
+        sessions.retain(|s| !s.is_sidechain);
+    }
     let from_d = parse_date_arg(&cli.from_date);
     let to_d = parse_date_arg(&cli.to_date);
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -950,7 +950,7 @@ pub fn parse_codex_jsonl(filepath: &str) -> Vec<Message> {
     let reader = BufReader::new(file);
     let entries: Vec<Value> = reader
         .lines()
-        .map_while(Result::ok)
+        .filter_map(Result::ok)
         .filter_map(|l| serde_json::from_str(l.trim()).ok())
         .collect();
     let skip_commentary = codex_commentary_to_skip(&entries);
@@ -1951,6 +1951,32 @@ mod tests {
                 .all(|m| !m.content.contains("inspect the files")),
             "commentary assistant messages should not be included"
         );
+    }
+
+    #[test]
+    fn parse_codex_jsonl_continues_past_invalid_utf8_lines() {
+        use std::io::Write;
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let mut f = std::fs::File::create(tmp.path()).unwrap();
+        writeln!(
+            f,
+            r#"{{"timestamp":"2026-06-10T10:00:01.000Z","type":"response_item","payload":{{"type":"message","role":"user","content":[{{"type":"input_text","text":"first prompt"}}]}}}}"#
+        )
+        .unwrap();
+        f.write_all(b"\xff\xfe invalid utf8 line \xff\n").unwrap();
+        writeln!(
+            f,
+            r#"{{"timestamp":"2026-06-10T10:00:03.000Z","type":"response_item","payload":{{"type":"message","role":"assistant","phase":"final_answer","content":[{{"type":"output_text","text":"answer after bad line"}}]}}}}"#
+        )
+        .unwrap();
+        drop(f);
+        let messages = parse_codex_jsonl(tmp.path().to_str().unwrap());
+        assert_eq!(
+            messages.len(),
+            2,
+            "lines after an invalid UTF-8 line must still be parsed"
+        );
+        assert_eq!(messages[1].content, "answer after bad line");
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -21,7 +21,6 @@ pub struct Session {
     pub branch: String,
     pub project: String,
     pub file: String,
-    #[allow(dead_code)]
     pub is_sidechain: bool,
 }
 
@@ -919,38 +918,61 @@ pub fn parse_claude_jsonl(
     (messages, None)
 }
 
+// Commentary-phase assistant messages are dropped only for turns that reach a
+// final_answer; interrupted turns have no other assistant text, so their
+// commentary is kept. A turn ends at the next user record (real or injected).
+fn codex_commentary_to_skip(entries: &[Value]) -> HashSet<usize> {
+    let mut skip = HashSet::new();
+    let mut open_commentary: Vec<usize> = Vec::new();
+    for (i, entry) in entries.iter().enumerate() {
+        let payload = codex_payload(entry);
+        if payload.get("type").and_then(Value::as_str) != Some("message") {
+            continue;
+        }
+        match payload.get("role").and_then(Value::as_str) {
+            Some("user") => open_commentary.clear(),
+            Some("assistant") => match payload.get("phase").and_then(Value::as_str) {
+                Some("commentary") => open_commentary.push(i),
+                Some("final_answer") => skip.extend(open_commentary.drain(..)),
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+    skip
+}
+
 pub fn parse_codex_jsonl(filepath: &str) -> Vec<Message> {
     let file = match fs::File::open(filepath) {
         Ok(f) => f,
         Err(_) => return Vec::new(),
     };
     let reader = BufReader::new(file);
+    let entries: Vec<Value> = reader
+        .lines()
+        .map_while(Result::ok)
+        .filter_map(|l| serde_json::from_str(l.trim()).ok())
+        .collect();
+    let skip_commentary = codex_commentary_to_skip(&entries);
+
     let mut messages: Vec<Message> = Vec::new();
     let mut session_id = String::new();
     let mut project_path = String::new();
     // Tool calls made before the assistant says anything; attached to the
     // next assistant message so they aren't lost.
     let mut pending_tools: Vec<String> = Vec::new();
+    // Set while a skipped commentary message is the turn's latest assistant
+    // output: tool calls must wait for the turn's final answer instead of
+    // attaching to the previous turn's message.
+    let mut route_tools_forward = false;
     let mut total_chars: usize = 0;
     let max_chars: usize = 4 * 1024 * 1024;
 
-    for line in reader.lines() {
-        let line = match line {
-            Ok(l) => l,
-            Err(_) => continue,
-        };
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let entry: Value = match serde_json::from_str(trimmed) {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
+    for (i, entry) in entries.iter().enumerate() {
         // session_meta carries id/cwd; legacy files put them flat on line 1.
         let etype = entry.get("type").and_then(Value::as_str);
         if etype == Some("session_meta") || (etype.is_none() && entry.get("id").is_some()) {
-            let p = codex_payload(&entry);
+            let p = codex_payload(entry);
             session_id = p
                 .get("id")
                 .and_then(Value::as_str)
@@ -968,16 +990,15 @@ pub fn parse_codex_jsonl(filepath: &str) -> Vec<Message> {
             .and_then(Value::as_str)
             .unwrap_or("")
             .to_string();
-        let payload = codex_payload(&entry);
+        let payload = codex_payload(entry);
         match payload.get("type").and_then(Value::as_str) {
             Some("message") => {
                 let role = payload.get("role").and_then(Value::as_str).unwrap_or("");
                 if role != "user" && role != "assistant" {
                     continue;
                 }
-                if role == "assistant"
-                    && payload.get("phase").and_then(Value::as_str) == Some("commentary")
-                {
+                if skip_commentary.contains(&i) {
+                    route_tools_forward = true;
                     continue;
                 }
                 let content_raw = payload
@@ -994,6 +1015,7 @@ pub fn parse_codex_jsonl(filepath: &str) -> Vec<Message> {
                     let mut tool_uses = ctx.tools;
                     if role == "assistant" {
                         tool_uses.append(&mut pending_tools);
+                        route_tools_forward = false;
                     }
                     messages.push(Message {
                         uuid: String::new(),
@@ -1016,7 +1038,7 @@ pub fn parse_codex_jsonl(filepath: &str) -> Vec<Message> {
             Some("function_call") => {
                 if let Some(name) = payload.get("name").and_then(Value::as_str) {
                     match messages.last_mut() {
-                        Some(last) if last.role == "assistant" => {
+                        Some(last) if last.role == "assistant" && !route_tools_forward => {
                             last.tool_uses.push(name.to_string());
                         }
                         _ => pending_tools.push(name.to_string()),
@@ -1794,6 +1816,61 @@ mod tests {
     }
 
     #[test]
+    fn claude_ai_title_custom_title_beats_later_ai_title() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let data = [
+            r#"{"type":"ai-title","aiTitle":"Auto title","sessionId":"abc"}"#,
+            r#"{"type":"custom-title","customTitle":"Manual title","sessionId":"abc"}"#,
+            r#"{"type":"ai-title","aiTitle":"Newer auto title","sessionId":"abc"}"#,
+        ]
+        .join("\n");
+        std::fs::write(tmp.path(), data).unwrap();
+        assert_eq!(
+            claude_ai_title(tmp.path()),
+            Some("Manual title".to_string())
+        );
+    }
+
+    // The tail window is a deliberate tradeoff: titles more than 64KB before
+    // EOF are not found during listing. These two tests pin both sides of it.
+    #[test]
+    fn claude_ai_title_finds_title_within_64k_tail_of_large_file() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let filler = format!(
+            r#"{{"type":"assistant","message":{{"role":"assistant","content":"{}"}}}}"#,
+            "x".repeat(200)
+        );
+        let mut lines: Vec<String> = std::iter::repeat_n(filler, 400).collect();
+        lines.push(r#"{"type":"ai-title","aiTitle":"Tail title","sessionId":"abc"}"#.to_string());
+        let data = lines.join("\n");
+        assert!(
+            data.len() > 64 * 1024,
+            "fixture must exceed the tail window"
+        );
+        std::fs::write(tmp.path(), data).unwrap();
+        assert_eq!(claude_ai_title(tmp.path()), Some("Tail title".to_string()));
+    }
+
+    #[test]
+    fn claude_ai_title_misses_title_older_than_64k_tail() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let filler = format!(
+            r#"{{"type":"assistant","message":{{"role":"assistant","content":"{}"}}}}"#,
+            "x".repeat(200)
+        );
+        let mut lines =
+            vec![r#"{"type":"ai-title","aiTitle":"Head title","sessionId":"abc"}"#.to_string()];
+        lines.extend(std::iter::repeat_n(filler, 400));
+        let data = lines.join("\n");
+        assert!(
+            data.len() > 64 * 1024,
+            "fixture must exceed the tail window"
+        );
+        std::fs::write(tmp.path(), data).unwrap();
+        assert_eq!(claude_ai_title(tmp.path()), None);
+    }
+
+    #[test]
     fn claude_ai_title_empty_custom_title_falls_back_to_ai_title() {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let data = [
@@ -1877,13 +1954,63 @@ mod tests {
     }
 
     #[test]
+    fn parse_codex_jsonl_keeps_commentary_for_turns_without_final_answer() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let data = r#"{"timestamp":"2026-06-10T10:00:00.000Z","type":"session_meta","payload":{"id":"s1","timestamp":"2026-06-10T10:00:00.000Z","cwd":"/p"}}
+{"timestamp":"2026-06-10T10:00:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"refactor the auth module"}]}}
+{"timestamp":"2026-06-10T10:00:02.000Z","type":"response_item","payload":{"type":"message","role":"assistant","phase":"commentary","content":[{"type":"output_text","text":"I found a blocker in the token refresh path."}]}}
+{"timestamp":"2026-06-10T10:00:03.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<turn_aborted>user interrupted</turn_aborted>"}]}}
+{"timestamp":"2026-06-10T10:00:04.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"just fix the login bug instead"}]}}
+{"timestamp":"2026-06-10T10:00:05.000Z","type":"response_item","payload":{"type":"message","role":"assistant","phase":"final_answer","content":[{"type":"output_text","text":"Login bug fixed."}]}}"#;
+        std::fs::write(tmp.path(), data).unwrap();
+        let messages = parse_codex_jsonl(tmp.path().to_str().unwrap());
+        let contents: Vec<&str> = messages.iter().map(|m| m.content.as_str()).collect();
+        assert!(
+            contents.contains(&"I found a blocker in the token refresh path."),
+            "commentary from an aborted turn (no final_answer) should be kept, got: {contents:?}"
+        );
+        assert!(contents.contains(&"Login bug fixed."));
+    }
+
+    #[test]
+    fn parse_codex_jsonl_attaches_tools_to_turn_final_answer_after_skipped_commentary() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let data = r#"{"timestamp":"2026-06-10T10:00:00.000Z","type":"session_meta","payload":{"id":"s1","timestamp":"2026-06-10T10:00:00.000Z","cwd":"/p"}}
+{"timestamp":"2026-06-10T10:00:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"do task A"}]}}
+{"timestamp":"2026-06-10T10:00:02.000Z","type":"response_item","payload":{"type":"message","role":"assistant","phase":"final_answer","content":[{"type":"output_text","text":"Task A is done."}]}}
+{"timestamp":"2026-06-10T10:00:03.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>\n<cwd>/p</cwd>"}]}}
+{"timestamp":"2026-06-10T10:00:04.000Z","type":"response_item","payload":{"type":"message","role":"assistant","phase":"commentary","content":[{"type":"output_text","text":"Checking the repo layout first."}]}}
+{"timestamp":"2026-06-10T10:00:05.000Z","type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{\"command\":[\"ls\"]}","call_id":"call_1"}}
+{"timestamp":"2026-06-10T10:00:06.000Z","type":"response_item","payload":{"type":"message","role":"assistant","phase":"final_answer","content":[{"type":"output_text","text":"Task B is done."}]}}"#;
+        std::fs::write(tmp.path(), data).unwrap();
+        let messages = parse_codex_jsonl(tmp.path().to_str().unwrap());
+        let task_a = messages
+            .iter()
+            .find(|m| m.content == "Task A is done.")
+            .expect("turn 1 final answer present");
+        let task_b = messages
+            .iter()
+            .find(|m| m.content == "Task B is done.")
+            .expect("turn 2 final answer present");
+        assert!(
+            task_a.tool_uses.is_empty(),
+            "turn 2's tool call must not attach to turn 1's answer, got {:?}",
+            task_a.tool_uses
+        );
+        assert_eq!(
+            task_b.tool_uses,
+            vec!["shell".to_string()],
+            "tool call after skipped commentary should attach to the turn's final answer"
+        );
+    }
+
+    #[test]
     #[ignore = "manual: requires local Claude transcript"]
     fn load_claude_sessions_populates_ai_title_summary() {
         let sessions = load_claude_sessions();
-        let s = sessions
-            .iter()
-            .find(|s| s.id.starts_with("5e081f75"))
-            .expect("session should exist locally");
+        let Some(s) = sessions.iter().find(|s| s.id.starts_with("5e081f75")) else {
+            return; // transcript only exists on the machine that recorded it
+        };
         assert!(
             !s.summary.is_empty(),
             "expected ai-title summary, got empty (branch={:?})",

--- a/src/session.rs
+++ b/src/session.rs
@@ -47,6 +47,7 @@ impl Message {
     }
 }
 
+#[derive(Default)]
 pub struct SessionMeta {
     pub summary: Option<String>,
     pub custom_title: Option<String>,
@@ -116,9 +117,14 @@ fn codex_sessions_dir() -> PathBuf {
     codex_home().join("sessions")
 }
 
-fn read_cwd_from_jsonl(path: &Path) -> Option<String> {
-    let file = fs::File::open(path).ok()?;
+// Reads cwd and gitBranch from the first records of a Claude transcript.
+fn read_cwd_branch_from_jsonl(path: &Path) -> (Option<String>, Option<String>) {
+    let Ok(file) = fs::File::open(path) else {
+        return (None, None);
+    };
     let reader = BufReader::new(file);
+    let mut cwd = None;
+    let mut branch = None;
     for line in reader.lines().take(10) {
         let line = match line {
             Ok(l) => l,
@@ -132,13 +138,77 @@ fn read_cwd_from_jsonl(path: &Path) -> Option<String> {
             Ok(v) => v,
             Err(_) => continue,
         };
-        if let Some(cwd) = entry.get("cwd").and_then(Value::as_str)
-            && !cwd.is_empty()
+        if cwd.is_none()
+            && let Some(c) = entry.get("cwd").and_then(Value::as_str)
+            && !c.is_empty()
         {
-            return Some(cwd.to_string());
+            cwd = Some(c.to_string());
+        }
+        if branch.is_none()
+            && let Some(b) = entry.get("gitBranch").and_then(Value::as_str)
+            && !b.is_empty()
+        {
+            branch = Some(b.to_string());
+        }
+        if cwd.is_some() && branch.is_some() {
+            break;
         }
     }
-    None
+    (cwd, branch)
+}
+
+// Current Claude Code appends ai-title records as the session title evolves;
+// the last one is the current title. Read from the tail to avoid scanning
+// whole transcripts during listing.
+fn claude_ai_title(path: &Path) -> Option<String> {
+    use std::io::{Read, Seek, SeekFrom};
+    let mut file = fs::File::open(path).ok()?;
+    let len = file.metadata().ok()?.len();
+    const TAIL: u64 = 64 * 1024;
+    let start = len.saturating_sub(TAIL);
+    file.seek(SeekFrom::Start(start)).ok()?;
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes).ok()?;
+    // The seek may land mid-character; decode lossily and skip the partial line.
+    let buf = String::from_utf8_lossy(&bytes);
+    let mut ai_title = None;
+    let mut custom_title_cleared = false;
+    for line in buf.lines().rev() {
+        if !line.contains("\"ai-title\"") && !line.contains("\"custom-title\"") {
+            continue;
+        }
+        let Ok(entry) = serde_json::from_str::<Value>(line.trim()) else {
+            continue;
+        };
+        match entry.get("type").and_then(Value::as_str) {
+            Some("custom-title") => {
+                if custom_title_cleared {
+                    continue;
+                }
+                let title = entry
+                    .get("customTitle")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .trim();
+                if !title.is_empty() {
+                    return Some(title.to_string());
+                }
+                custom_title_cleared = true;
+            }
+            Some("ai-title") if ai_title.is_none() => {
+                let title = entry
+                    .get("aiTitle")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .trim();
+                if !title.is_empty() {
+                    ai_title = Some(title.to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+    ai_title
 }
 
 pub fn encode_path_for_claude(path: &Path) -> String {
@@ -364,23 +434,25 @@ pub fn load_claude_sessions() -> Vec<Session> {
                     }
                     let iso = mtime_iso(&path).unwrap_or_default();
                     let date = mtime_date(&path).unwrap_or_default();
-                    let project = read_cwd_from_jsonl(&path).unwrap_or_else(|| {
+                    let (cwd, branch) = read_cwd_branch_from_jsonl(&path);
+                    let project = cwd.unwrap_or_else(|| {
                         dir.file_name()
                             .unwrap_or_default()
                             .to_string_lossy()
                             .replace('-', "/")
                     });
+                    let summary = claude_ai_title(&path).unwrap_or_default();
                     let first = claude_first_prompt(&path);
                     sessions.push(Session {
                         source: "claude".into(),
                         id: sid,
-                        summary: String::new(),
+                        summary,
                         first_prompt: first,
                         created: iso.clone(),
                         modified: iso,
                         date,
                         messages: 0,
-                        branch: String::new(),
+                        branch: branch.unwrap_or_default(),
                         project,
                         file: path.to_string_lossy().to_string(),
                         is_sidechain: false,
@@ -451,6 +523,37 @@ pub fn load_cursor_sessions() -> Vec<Session> {
                 }
             }
             for (dirname, path) in dir_entries {
+                let subagents = path.join("subagents");
+                if let Ok(entries) = fs::read_dir(&subagents) {
+                    for entry in entries.flatten() {
+                        let subagent_path = entry.path();
+                        if subagent_path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                            continue;
+                        }
+                        let sid = subagent_path
+                            .file_stem()
+                            .unwrap_or_default()
+                            .to_string_lossy()
+                            .to_string();
+                        let iso = mtime_iso(&subagent_path).unwrap_or_default();
+                        let date = mtime_date(&subagent_path).unwrap_or_default();
+                        let first = cursor_first_prompt_jsonl(&subagent_path);
+                        sessions.push(Session {
+                            source: "cursor".into(),
+                            id: sid,
+                            summary: String::new(),
+                            first_prompt: first,
+                            created: iso.clone(),
+                            modified: iso,
+                            date,
+                            messages: 0,
+                            branch: String::new(),
+                            project: pd.file_name().to_string_lossy().to_string(),
+                            file: subagent_path.to_string_lossy().to_string(),
+                            is_sidechain: true,
+                        });
+                    }
+                }
                 if txt_ids.contains(&dirname) {
                     continue;
                 }
@@ -647,12 +750,7 @@ pub fn parse_claude_jsonl(
             return (
                 Vec::new(),
                 if extract_meta {
-                    Some(SessionMeta {
-                        summary: None,
-                        custom_title: None,
-                        model: None,
-                        total_tokens: 0,
-                    })
+                    Some(SessionMeta::default())
                 } else {
                     None
                 },
@@ -661,12 +759,7 @@ pub fn parse_claude_jsonl(
     };
     let reader = BufReader::new(file);
     let mut messages = Vec::new();
-    let mut meta = SessionMeta {
-        summary: None,
-        custom_title: None,
-        model: None,
-        total_tokens: 0,
-    };
+    let mut meta = SessionMeta::default();
     let mut skip_next_assistant = false;
     let mut user_texts = Vec::new();
     let mut total_chars: usize = 0;
@@ -694,16 +787,24 @@ pub fn parse_claude_jsonl(
                 .map(String::from);
             continue;
         }
-        if etype == "custom_title" && extract_meta && meta.custom_title.is_none() {
+        if etype == "ai-title" && extract_meta {
+            if let Some(title) = entry.get("aiTitle").and_then(Value::as_str) {
+                let title = title.trim();
+                if !title.is_empty() {
+                    meta.summary = Some(title.to_string());
+                }
+            }
+            continue;
+        }
+        if (etype == "custom-title" || etype == "custom_title") && extract_meta {
             let title = entry
-                .get("custom_title")
+                .get("customTitle")
+                .or_else(|| entry.get("custom_title"))
                 .and_then(Value::as_str)
                 .unwrap_or("")
                 .trim()
                 .to_string();
-            if !title.is_empty() {
-                meta.custom_title = Some(title);
-            }
+            meta.custom_title = if title.is_empty() { None } else { Some(title) };
             continue;
         }
 
@@ -872,6 +973,11 @@ pub fn parse_codex_jsonl(filepath: &str) -> Vec<Message> {
             Some("message") => {
                 let role = payload.get("role").and_then(Value::as_str).unwrap_or("");
                 if role != "user" && role != "assistant" {
+                    continue;
+                }
+                if role == "assistant"
+                    && payload.get("phase").and_then(Value::as_str) == Some("commentary")
+                {
                     continue;
                 }
                 let content_raw = payload
@@ -1061,15 +1167,7 @@ pub fn parse_session(session: &Session, extract_meta: bool) -> (Vec<Message>, Op
     if session.source == "codex" {
         let messages = parse_codex_jsonl(&session.file);
         if extract_meta {
-            return (
-                messages,
-                Some(SessionMeta {
-                    summary: None,
-                    custom_title: None,
-                    model: None,
-                    total_tokens: 0,
-                }),
-            );
+            return (messages, Some(SessionMeta::default()));
         }
         return (messages, None);
     }
@@ -1496,7 +1594,7 @@ mod tests {
 {"timestamp":"2026-06-10T10:00:01.000Z","type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"<permissions instructions>\nsandbox stuff"}]}}
 {"timestamp":"2026-06-10T10:00:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>\n<cwd>/Users/test/myproj</cwd>\n</environment_context>"}]}}
 {"timestamp":"2026-06-10T10:00:02.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"add connection pooling to the database layer"}]}}
-{"timestamp":"2026-06-10T10:00:05.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"I'll add connection pooling using a bounded pool."}],"phase":"commentary"}}
+{"timestamp":"2026-06-10T10:00:05.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"I'll add connection pooling using a bounded pool."}],"phase":"final_answer"}}
 {"timestamp":"2026-06-10T10:00:06.000Z","type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{\"command\":[\"ls\"]}","call_id":"call_1"}}
 {"timestamp":"2026-06-10T10:00:07.000Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_1","output":"src tests"}}
 {"timestamp":"2026-06-10T10:00:09.000Z","type":"event_msg","payload":{"type":"token_count","info":{}}}"#;
@@ -1660,22 +1758,155 @@ mod tests {
     }
 
     #[test]
-    fn read_cwd_from_jsonl_extracts_cwd() {
+    fn read_cwd_branch_from_jsonl_extracts_cwd_and_branch() {
         let tmp = tempfile::NamedTempFile::new().unwrap();
-        let data = r#"{"type":"user","cwd":"/Users/test/project","message":{"content":"hello"}}"#;
+        let data = r#"{"type":"user","cwd":"/Users/test/project","gitBranch":"feature-x","message":{"content":"hello"}}"#;
         std::fs::write(tmp.path(), data).unwrap();
         assert_eq!(
-            read_cwd_from_jsonl(tmp.path()),
-            Some("/Users/test/project".to_string())
+            read_cwd_branch_from_jsonl(tmp.path()),
+            (
+                Some("/Users/test/project".to_string()),
+                Some("feature-x".to_string())
+            )
         );
     }
 
     #[test]
-    fn read_cwd_from_jsonl_no_cwd() {
+    fn read_cwd_branch_from_jsonl_no_fields() {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let data = r#"{"type":"user","message":{"content":"hello"}}"#;
         std::fs::write(tmp.path(), data).unwrap();
-        assert_eq!(read_cwd_from_jsonl(tmp.path()), None);
+        assert_eq!(read_cwd_branch_from_jsonl(tmp.path()), (None, None));
+    }
+
+    #[test]
+    fn claude_ai_title_reads_last_title_from_tail() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let mut lines =
+            vec![r#"{"type":"ai-title","aiTitle":"First title","sessionId":"abc"}"#.to_string()];
+        lines.extend(std::iter::repeat_n(
+            r#"{"type":"assistant","message":{"role":"assistant","content":"x"}}"#.to_string(),
+            50,
+        ));
+        lines.push(r#"{"type":"ai-title","aiTitle":"Final title","sessionId":"abc"}"#.to_string());
+        std::fs::write(tmp.path(), lines.join("\n")).unwrap();
+        assert_eq!(claude_ai_title(tmp.path()), Some("Final title".to_string()));
+    }
+
+    #[test]
+    fn claude_ai_title_empty_custom_title_falls_back_to_ai_title() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let data = [
+            r#"{"type":"ai-title","aiTitle":"Auto title","sessionId":"abc"}"#,
+            r#"{"type":"custom-title","customTitle":"Manual title","sessionId":"abc"}"#,
+            r#"{"type":"custom-title","customTitle":"","sessionId":"abc"}"#,
+        ]
+        .join("\n");
+        std::fs::write(tmp.path(), data).unwrap();
+        assert_eq!(claude_ai_title(tmp.path()), Some("Auto title".to_string()));
+    }
+
+    #[test]
+    fn parse_claude_jsonl_ai_title_updates_summary() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let data = concat!(
+            r#"{"type":"ai-title","aiTitle":"Old title"}"#,
+            "\n",
+            r#"{"type":"user","message":{"role":"user","content":"hi"}}"#,
+            "\n",
+            r#"{"type":"ai-title","aiTitle":"Current title"}"#,
+        );
+        std::fs::write(tmp.path(), data).unwrap();
+        let (_, meta) = parse_claude_jsonl(tmp.path().to_str().unwrap(), true);
+        assert_eq!(meta.unwrap().summary.as_deref(), Some("Current title"));
+    }
+
+    #[test]
+    fn parse_claude_jsonl_custom_title_overrides_ai_title() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let data = concat!(
+            r#"{"type":"ai-title","aiTitle":"Auto title"}"#,
+            "\n",
+            r#"{"type":"custom-title","customTitle":"Manual title"}"#,
+            "\n",
+            r#"{"type":"user","message":{"role":"user","content":"hi"}}"#,
+        );
+        std::fs::write(tmp.path(), data).unwrap();
+        let (_, meta) = parse_claude_jsonl(tmp.path().to_str().unwrap(), true);
+        let meta = meta.unwrap();
+        assert_eq!(meta.summary.as_deref(), Some("Auto title"));
+        assert_eq!(meta.custom_title.as_deref(), Some("Manual title"));
+    }
+
+    #[test]
+    fn parse_claude_jsonl_empty_custom_title_clears_manual_title() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let data = concat!(
+            r#"{"type":"ai-title","aiTitle":"Auto title"}"#,
+            "\n",
+            r#"{"type":"custom-title","customTitle":"Manual title"}"#,
+            "\n",
+            r#"{"type":"custom-title","customTitle":""}"#,
+            "\n",
+            r#"{"type":"user","message":{"role":"user","content":"hi"}}"#,
+        );
+        std::fs::write(tmp.path(), data).unwrap();
+        let (_, meta) = parse_claude_jsonl(tmp.path().to_str().unwrap(), true);
+        let meta = meta.unwrap();
+        assert_eq!(meta.summary.as_deref(), Some("Auto title"));
+        assert_eq!(meta.custom_title, None);
+    }
+
+    #[test]
+    fn parse_codex_jsonl_skips_commentary_assistant_messages() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let data = r#"{"timestamp":"2026-06-10T10:00:00.000Z","type":"session_meta","payload":{"id":"s1","timestamp":"2026-06-10T10:00:00.000Z","cwd":"/p"}}
+{"timestamp":"2026-06-10T10:00:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"fix the parser"}]}}
+{"timestamp":"2026-06-10T10:00:02.000Z","type":"response_item","payload":{"type":"message","role":"assistant","phase":"commentary","content":[{"type":"output_text","text":"I will inspect the files first."}]}}
+{"timestamp":"2026-06-10T10:00:03.000Z","type":"response_item","payload":{"type":"message","role":"assistant","phase":"final_answer","content":[{"type":"output_text","text":"The parser is fixed."}]}}"#;
+        std::fs::write(tmp.path(), data).unwrap();
+        let messages = parse_codex_jsonl(tmp.path().to_str().unwrap());
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[1].content, "The parser is fixed.");
+        assert!(
+            messages
+                .iter()
+                .all(|m| !m.content.contains("inspect the files")),
+            "commentary assistant messages should not be included"
+        );
+    }
+
+    #[test]
+    #[ignore = "manual: requires local Claude transcript"]
+    fn load_claude_sessions_populates_ai_title_summary() {
+        let sessions = load_claude_sessions();
+        let s = sessions
+            .iter()
+            .find(|s| s.id.starts_with("5e081f75"))
+            .expect("session should exist locally");
+        assert!(
+            !s.summary.is_empty(),
+            "expected ai-title summary, got empty (branch={:?})",
+            s.branch
+        );
+        assert!(!s.branch.is_empty(), "expected gitBranch from JSONL");
+    }
+
+    #[test]
+    #[ignore = "manual: requires local Claude transcript"]
+    fn claude_ai_title_real_session() {
+        let p = Path::new(concat!(
+            env!("HOME"),
+            "/.claude/projects/-Users-ayushbhardwaj-Documents-GitHub-chat-history/",
+            "5e081f75-04b9-4461-a805-8bfb9f8c75fc.jsonl"
+        ));
+        if !p.exists() {
+            return;
+        }
+        assert_eq!(
+            claude_ai_title(p).as_deref(),
+            Some("Add Codex chat-history integrations with graceful fallbacks")
+        );
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -943,14 +943,14 @@ fn codex_commentary_to_skip(entries: &[Value]) -> HashSet<usize> {
 }
 
 pub fn parse_codex_jsonl(filepath: &str) -> Vec<Message> {
-    let file = match fs::File::open(filepath) {
-        Ok(f) => f,
-        Err(_) => return Vec::new(),
+    // Whole-file read + lossy decode: an unreadable path fails once up front
+    // (io::Lines can yield Err forever), and an invalid UTF-8 line only
+    // corrupts itself instead of truncating the rest of the transcript.
+    let Ok(bytes) = fs::read(filepath) else {
+        return Vec::new();
     };
-    let reader = BufReader::new(file);
-    let entries: Vec<Value> = reader
+    let entries: Vec<Value> = String::from_utf8_lossy(&bytes)
         .lines()
-        .filter_map(Result::ok)
         .filter_map(|l| serde_json::from_str(l.trim()).ok())
         .collect();
     let skip_commentary = codex_commentary_to_skip(&entries);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -147,6 +147,43 @@ fn setup_fixture(tmp: &TempDir) {
     .unwrap();
 }
 
+// A modern Claude session: JSONL transcript only, no sessions-index.json.
+// Summary/branch must come from the ai-title and gitBranch records.
+fn setup_claude_jsonl_only_fixture(tmp: &TempDir) {
+    let project_dir = tmp.path().join("projects").join("-Users-test-webapp");
+    fs::create_dir_all(&project_dir).unwrap();
+    let session_id = "dddddddd-eeee-ffff-0000-111111111111";
+    let lines = [
+        serde_json::json!({"type":"user","cwd":"/Users/test/webapp","gitBranch":"feat-login","message":{"role":"user","content":"wire up login form validation"},"timestamp":"2025-03-01T10:00:00Z","uuid":"u1"}),
+        serde_json::json!({"type":"assistant","message":{"role":"assistant","content":"Added validation to the login form."},"timestamp":"2025-03-01T10:01:00Z","uuid":"u2"}),
+        serde_json::json!({"type":"ai-title","aiTitle":"Login form validation","sessionId":session_id}),
+    ];
+    fs::write(
+        project_dir.join(format!("{session_id}.jsonl")),
+        lines
+            .into_iter()
+            .map(|v| serde_json::to_string(&v).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n"),
+    )
+    .unwrap();
+}
+
+#[test]
+fn claude_jsonl_only_session_lists_ai_title_and_branch() {
+    let tmp = TempDir::new().unwrap();
+    setup_claude_jsonl_only_fixture(&tmp);
+    Command::cargo_bin("chat-history")
+        .unwrap()
+        .env("CLAUDE_CONFIG_DIR", tmp.path())
+        .env("HOME", tmp.path())
+        .env("NO_COLOR", "1")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Login form validation"))
+        .stdout(predicate::str::contains("(feat-login)"));
+}
+
 #[test]
 fn list_shows_fixture_sessions() {
     let tmp = TempDir::new().unwrap();
@@ -1102,7 +1139,7 @@ fn cursor_session_deep_search() {
 }
 
 #[test]
-fn cursor_subagent_sessions_listed_and_searchable() {
+fn cursor_subagent_sessions_hidden_by_default() {
     let tmp = TempDir::new().unwrap();
     setup_cursor_subagent_fixture(&tmp);
 
@@ -1114,7 +1151,7 @@ fn cursor_subagent_sessions_listed_and_searchable() {
         .env("NO_COLOR", "1")
         .assert()
         .success()
-        .stdout(predicate::str::contains("audit parser edge cases"));
+        .stdout(predicate::str::contains("audit parser edge cases").not());
 
     Command::cargo_bin("chat-history")
         .unwrap()
@@ -1124,6 +1161,41 @@ fn cursor_subagent_sessions_listed_and_searchable() {
             "--source",
             "cursor",
             "--deep",
+        ])
+        .env("HOME", tmp.path())
+        .env("CLAUDE_CONFIG_DIR", tmp.path())
+        .env("NO_COLOR", "1")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No results"))
+        .stdout(predicate::str::contains("parser edge case").not());
+}
+
+#[test]
+fn cursor_subagent_sessions_listed_and_searchable_with_flag() {
+    let tmp = TempDir::new().unwrap();
+    setup_cursor_subagent_fixture(&tmp);
+
+    Command::cargo_bin("chat-history")
+        .unwrap()
+        .args(["--source", "cursor", "--sidechains"])
+        .env("HOME", tmp.path())
+        .env("CLAUDE_CONFIG_DIR", tmp.path())
+        .env("NO_COLOR", "1")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("audit parser edge cases"))
+        .stdout(predicate::str::contains("[subagent]"));
+
+    Command::cargo_bin("chat-history")
+        .unwrap()
+        .args([
+            "search",
+            "subagent analysis",
+            "--source",
+            "cursor",
+            "--deep",
+            "--sidechains",
         ])
         .env("HOME", tmp.path())
         .env("CLAUDE_CONFIG_DIR", tmp.path())

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -315,7 +315,7 @@ fn setup_transcript_fixture(tmp: &TempDir) {
     let session_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
     let jsonl_path = project_dir.join(format!("{session_id}.jsonl"));
 
-    let messages = vec![
+    let messages = [
         serde_json::json!({"type":"user","cwd":"/Users/test/project","message":{"role":"user","content":"help me configure webpack for production builds"},"timestamp":"2025-01-15T10:00:00Z","uuid":"u1"}),
         serde_json::json!({"type":"assistant","message":{"role":"assistant","content":"I'll help you configure webpack for production. Here's the optimized configuration with code splitting and tree shaking enabled for better performance."},"timestamp":"2025-01-15T10:01:00Z","uuid":"u2"}),
         serde_json::json!({"type":"user","message":{"role":"user","content":"now add the docker deployment configuration"},"timestamp":"2025-01-15T10:02:00Z","uuid":"u3"}),
@@ -357,7 +357,7 @@ fn setup_rich_transcript_fixture(tmp: &TempDir) {
     let session_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
     let jsonl_path = project_dir.join(format!("{session_id}.jsonl"));
 
-    let messages = vec![
+    let messages = [
         serde_json::json!({
             "type": "user",
             "cwd": "/Users/test/project",
@@ -728,7 +728,7 @@ fn deep_search_json_combined() {
     let first = &results[0];
     assert_eq!(first["session_id"], "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
     assert!(
-        first["snippet"].as_str().unwrap().len() > 0,
+        !first["snippet"].as_str().unwrap().is_empty(),
         "snippet should have content"
     );
     assert!(
@@ -855,6 +855,38 @@ fn setup_cursor_fixture(tmp: &TempDir) {
     fs::write(
         transcripts_dir.join(format!("{session_id}.txt")),
         txt_content,
+    )
+    .unwrap();
+}
+
+fn setup_cursor_subagent_fixture(tmp: &TempDir) {
+    let transcripts_dir = tmp
+        .path()
+        .join(".cursor")
+        .join("projects")
+        .join("Users-test-myapp")
+        .join("agent-transcripts");
+    let parent_id = "cccccccc-dddd-eeee-ffff-000000000000";
+    let subagent_id = "eeeeeeee-ffff-0000-1111-222222222222";
+    let subagents_dir = transcripts_dir.join(parent_id).join("subagents");
+    fs::create_dir_all(&subagents_dir).unwrap();
+    let jsonl = [
+        serde_json::json!({
+            "role": "user",
+            "message": {"content": [{"type": "text", "text": "audit parser edge cases"}]}
+        }),
+        serde_json::json!({
+            "role": "assistant",
+            "message": {"content": [{"type": "text", "text": "I found a parser edge case in subagent analysis."}]}
+        }),
+    ];
+    fs::write(
+        subagents_dir.join(format!("{subagent_id}.jsonl")),
+        jsonl
+            .into_iter()
+            .map(|v| serde_json::to_string(&v).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n"),
     )
     .unwrap();
 }
@@ -1067,6 +1099,38 @@ fn cursor_session_deep_search() {
         .assert()
         .success()
         .stdout(predicate::str::contains("pooling"));
+}
+
+#[test]
+fn cursor_subagent_sessions_listed_and_searchable() {
+    let tmp = TempDir::new().unwrap();
+    setup_cursor_subagent_fixture(&tmp);
+
+    Command::cargo_bin("chat-history")
+        .unwrap()
+        .args(["--source", "cursor"])
+        .env("HOME", tmp.path())
+        .env("CLAUDE_CONFIG_DIR", tmp.path())
+        .env("NO_COLOR", "1")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("audit parser edge cases"));
+
+    Command::cargo_bin("chat-history")
+        .unwrap()
+        .args([
+            "search",
+            "subagent analysis",
+            "--source",
+            "cursor",
+            "--deep",
+        ])
+        .env("HOME", tmp.path())
+        .env("CLAUDE_CONFIG_DIR", tmp.path())
+        .env("NO_COLOR", "1")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("subagent analysis"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Parse modern Claude Code JSONL metadata (`ai-title`, `custom-title`, cwd, and `gitBranch`) without depending on `sessions-index.json`.
- Discover Cursor subagent JSONL transcripts as separate Cursor sessions — hidden by default, included via the new global `--sidechains` flag and tagged `[subagent]` in listings.
- Filter Codex commentary-phase assistant messages from view/deep parsing for turns that reached a `final_answer`; interrupted turns keep their commentary so aborted work stays visible/searchable. Tool calls after skipped commentary attach to the turn's final answer, not the previous turn.
- Update docs for current source layouts and the new flag.

## Review fixes (second commit)
- Subagent sessions no longer flood the default listing (was +50% for cursor); `is_sidechain` is now actually honored.
- Codex aborted turns no longer lose all assistant content; fixed cross-turn tool misattribution.
- New hermetic CLI test for the JSONL-only metadata path (no `sessions-index.json`), tests pinning both sides of the 64KB title tail window, and custom-title-beats-later-ai-title precedence.
- Ignored manual test now skips instead of panicking on machines without the referenced transcript.

## Test plan
- `cargo test` (153 unit + 56 CLI)
- `cargo test -- --ignored` (manual, local transcripts)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- Local smoke check against real `~/.claude`, `~/.cursor`, `~/.codex` data: default cursor listing back to 112 sessions, 168 with `--sidechains` (56 tagged); aborted-turn Codex commentary visible in `view` while completed-turn commentary stays filtered.