### PR TITLE
Auto-install managed agent skills and rewrite SKILL.md as a workflow skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ The first time you run `chat-history` / `ch`, it quietly installs the bundled ag
 - `~/.claude/skills/chat-history/SKILL.md`
 - `$CODEX_HOME/skills/chat-history/SKILL.md` (or `~/.codex/...`)
 
-On Windows, the same paths are under `%USERPROFILE%`. Later CLI upgrades refresh **managed** copies automatically. User-edited skills are left alone.
+On Windows, the same paths are under `%USERPROFILE%`. Later CLI upgrades refresh **managed** copies automatically (those written by this CLI, tracked via a `.chat-history-managed` sidecar). User-edited skills are left alone. Skills installed by older versions without that sidecar are left alone by the quiet path — run `install-skill` once after upgrading to adopt them.
 
 Optional explicit install / reinstall:
 
 ```bash
-chat-history install-skill           # same rules as auto-install
+chat-history install-skill           # refresh managed + adopt legacy (pre-sidecar) installs
 chat-history install-skill --force   # overwrite even user-edited skills
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,18 +12,26 @@ Scoring logic ported from [claude-historian-mcp](https://github.com/Vvkmnn/claud
 
 ```bash
 cargo install chat-history
-chat-history install-skill
 ```
 
 `cargo install` puts `chat-history` and `ch` on `PATH` (`~/.cargo/bin/`).
 
-`install-skill` writes the bundled skill to:
+The first time you run `chat-history` / `ch`, it quietly installs the bundled agent skill to:
 
 - `~/.cursor/skills/chat-history/SKILL.md`
 - `~/.claude/skills/chat-history/SKILL.md`
 - `$CODEX_HOME/skills/chat-history/SKILL.md` (or `~/.codex/...`)
 
-Re-run `install-skill` after upgrades. The skill is active immediately — no restart needed.
+On Windows, the same paths are under `%USERPROFILE%`. Later CLI upgrades refresh **managed** copies automatically. User-edited skills are left alone.
+
+Optional explicit install / reinstall:
+
+```bash
+chat-history install-skill           # same rules as auto-install
+chat-history install-skill --force   # overwrite even user-edited skills
+```
+
+The skill is active immediately — no restart needed.
 
 ### Build from source
 
@@ -31,8 +39,9 @@ Re-run `install-skill` after upgrades. The skill is active immediately — no re
 git clone https://github.com/ay-bh/chat-history.git
 cd chat-history
 cargo install --path .
-chat-history install-skill
 ```
+
+Run any `chat-history` command once to install the skill (or `chat-history install-skill`).
 
 ## Agent usage
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -15,10 +15,10 @@ cargo install chat-history
 
 This installs both `chat-history` and `ch` (short alias) into `~/.cargo/bin/`.
 
-The skill is installed automatically the first time the CLI runs (and managed copies are refreshed on later upgrades). Optional:
+The skill is installed automatically the first time the CLI runs. Managed copies (with a `.chat-history-managed` sidecar) refresh on later upgrades; user-edited skills are left alone. After upgrading from a pre-sidecar install, run `install-skill` once to adopt the new skill.
 
 ```bash
-chat-history install-skill           # explicit install / status
+chat-history install-skill           # refresh managed + adopt legacy installs
 chat-history install-skill --force   # overwrite user-edited skills
 ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -15,6 +15,13 @@ cargo install chat-history
 
 This installs both `chat-history` and `ch` (short alias) into `~/.cargo/bin/`.
 
+The skill is installed automatically the first time the CLI runs (and managed copies are refreshed on later upgrades). Optional:
+
+```bash
+chat-history install-skill           # explicit install / status
+chat-history install-skill --force   # overwrite user-edited skills
+```
+
 ## When to use
 
 - User asks about past conversations or sessions

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,83 +5,75 @@ description: Search, inspect, and export Claude Code, Cursor, and Codex conversa
 
 # chat-history
 
-Repo: https://github.com/ay-bh/chat-history
-
-## Install
-
-```bash
-cargo install chat-history
-```
-
-This installs both `chat-history` and `ch` (short alias) into `~/.cargo/bin/`.
-
-The skill is installed automatically the first time the CLI runs. Managed copies (with a `.chat-history-managed` sidecar) refresh on later upgrades; user-edited skills are left alone. After upgrading from a pre-sidecar install, run `install-skill` once to adopt the new skill.
-
-```bash
-chat-history install-skill           # refresh managed + adopt legacy installs
-chat-history install-skill --force   # overwrite user-edited skills
-```
+Search, inspect, and export Claude Code, Cursor, and Codex conversation history. The short alias `ch` works identically. If the command is not found: `cargo install chat-history`.
 
 ## When to use
 
 - User asks about past conversations or sessions
 - User wants to find something they discussed before
 - User needs a summary of recent work / accomplishments
-- User wants to search across Claude Code, Cursor, or Codex history
 - User wants to resume or export a previous session
+
+## Process
+
+**Keyword question** ("find that conversation where I..."):
+
+1. `chat-history search "<query>" --deep --json` — always `--deep --json` from agents. `--deep` searches full transcript content; `--json` returns structured results (`session_id`, `score`, `snippet`, `tools`, `files`). Note `--json` exists only on `search`.
+2. Shortlist by snippet, not by raw score (see "Choosing the best hit").
+3. `chat-history inspect <partial-uuid>` on the top 2–3 candidates to confirm before answering.
+4. `view` / `export` only if the user needs the actual content.
+
+**Temporal question** ("what did I work on yesterday?") — list, don't search:
+
+1. `chat-history --from yesterday --to yesterday -v` — `-v` shows session IDs.
+   - `--from X` alone means **X through today**. Always pair with `--to` when the user means a specific day.
+   - `-s` groups by day for multi-day overviews, but the grouped view hides session IDs even with `-v` — use the flat `-v` list when you need IDs.
+2. `chat-history inspect <id>` for accomplishments, tools, files touched.
+
+## Choosing the best hit
+
+- Scores rank keyword density, not intent. Use scores only to shortlist; decide from snippets and `inspect`.
+- The conversation you are currently in can match its own query and score highest. Ignore hits whose session is the current one.
+- When candidates are close, `inspect` each before picking — don't answer from the top score alone.
+
+## Common mistakes
+
+- Only `search` accepts `--json`; the session list and `inspect` reject it.
+- The session list shows no IDs unless you pass `-v`.
+- The only subcommands are `search`, `inspect`, `view`, `export`, `resume`, `find`, `install-skill`. Do not guess others; run `chat-history --help` when unsure.
+- Don't dump raw JSON or full transcripts at the user — summarize, cite the session ID and date.
+- Some Cursor sessions have thin metadata (`(no summary)`, `duration: 0min`, raw first-message titles). If `inspect` is thin, fall back to `chat-history view <id> --plain`.
 
 ## Commands
 
 ```bash
 # List sessions
-chat-history                               # all sessions, newest first
-chat-history --from yesterday -s           # grouped by day
-chat-history --from "3 days ago"           # natural language dates
-chat-history --source claude               # Claude Code only
-chat-history --source cursor               # Cursor only
-chat-history --source codex                # Codex only
-chat-history -L                            # current workspace only
-chat-history --branch feature-xyz          # filter by branch
-chat-history -k "auth" -v                  # keyword filter, show IDs
+chat-history                                      # newest first (-v for IDs and paths)
+chat-history --from yesterday --to yesterday -s   # a specific day, grouped
+chat-history --from "3 days ago"                  # natural-language dates
+chat-history --source claude                      # claude | cursor | codex
+chat-history -L                                   # current workspace only
+chat-history --branch feature-xyz -k "auth" -v    # branch / keyword filters
 
-# Search (always use --deep --json for best results from agents)
-chat-history search "auth error" --deep --json   # full transcript search, structured output
-chat-history search "fix" --scope errors --deep  # error patterns only
-chat-history search "trade" --scope similar      # similar past queries
-chat-history search <full-uuid>                  # direct UUID lookup
+# Search (always --deep --json from agents)
+chat-history search "auth error" --deep --json
+chat-history search "fix" --scope errors --deep --json   # only messages with error patterns
+chat-history search <full-uuid>                          # direct session lookup
+chat-history search "q" --deep --json --limit 30         # default limit is 15
 
-# Inspect (session summary)
-chat-history inspect --last                # accomplishments, tools, model, tokens
+# Inspect / View / Export / Resume / Find
+chat-history inspect --last                # accomplishments, tools, model, tokens, files
 chat-history inspect <partial-uuid>
-
-# View / Export / Resume / Find
-chat-history view --last --plain           # pipe-friendly plain text
-chat-history view <id> --tools             # show tool call names
-chat-history export <id> -o session.md     # export as markdown
-chat-history resume <id>                   # resume Claude Code or Codex session
-chat-history find <id>                     # print file path for scripting
+chat-history view <id> --plain             # transcript, pipe-friendly (--tools for tool names)
+chat-history export <id> -o session.md
+chat-history resume <id>                   # resume a Claude Code or Codex session
+chat-history find <id>                     # print transcript file path for scripting
 ```
 
-The short alias `ch` works identically: `ch search "auth"`, `ch inspect --last`, etc.
-
-## Search behavior
-
-- Always use `--deep --json` when calling from an agent for thorough results and structured output.
-- **Deep search** (`--deep`): Searches full transcript content across all messages in parallel.
-  - Snippets show context **around the match**, not the first N characters of the message.
-- **JSON output** (`--json`): Returns structured JSON with `session_id`, `score`, `snippet`, `tools`, `files`.
+- `--scope` values: `all` (default), `errors` (messages with error patterns or the word "error"), `similar` (user messages only — similar past queries), `tools` (messages with tool calls), `files` (messages referencing files). Any scope other than `all` always searches full transcripts.
+- Shared filters on every subcommand: `--from`/`--to`, `--source`, `--project`, `--branch`, `-k`, `--sidechains` (include hidden subagent sessions).
 
 ## Interpreting output
 
-- `CC` = Claude Code session, `CR` = Cursor session, `CX` = Codex session
-- Score (`★ N.N`) = relevance score (higher = better match)
-- `[summary]`, `[first_prompt]`, `[branch]` = which field matched in index search
-- `inspect` shows: duration, message count, model name, token count, tools used, files touched, accomplishments, key decisions
-- Claude Code titles come from modern `ai-title` / `custom-title` JSONL records when available
-- Cursor subagent transcripts under `agent-transcripts/*/subagents/` are hidden by default; pass `--sidechains` to list them (tagged `[subagent]`)
-- Codex commentary-phase assistant messages are hidden for turns that reached a final answer; interrupted turns keep their commentary
-- Codex sessions are read from `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-*.jsonl` (or `~/.codex` by default)
-
-## Date formats accepted
-
-`YYYY-MM-DD`, `today`, `yesterday`, `"3 days ago"`, `"last week"`, `"last month"`
+- `CC` = Claude Code, `CR` = Cursor, `CX` = Codex; `★ N.N` = relevance score.
+- Accepted dates: `YYYY-MM-DD`, `today`, `yesterday`, `"3 days ago"`, `"last week"`, `"last month"`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@ pub mod parser;
 pub mod scoring;
 pub mod search;
 pub mod session;
+pub mod skill_install;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use chat_history::dates::parse_human_date;
 use chat_history::session::{
     self, filter_sessions, find_session, load_all_sessions, parse_session,
 };
+use chat_history::skill_install::{ensure_skills, install_skill};
 use chat_history::{display, inspect, scoring, search};
 use clap::{Parser, Subcommand};
 
@@ -100,53 +101,11 @@ enum Commands {
     },
     /// Install the agent skill for Claude Code, Cursor, and Codex
     #[command(name = "install-skill")]
-    InstallSkill,
-}
-
-const SKILL_CONTENT: &str = include_str!("../SKILL.md");
-
-fn skill_targets() -> Vec<(std::path::PathBuf, &'static str)> {
-    let Ok(home) = std::env::var("HOME") else {
-        return vec![];
-    };
-    let home = std::path::Path::new(&home);
-    vec![
-        (home.join(".cursor/skills/chat-history"), "Cursor"),
-        (home.join(".claude/skills/chat-history"), "Claude Code"),
-        (session::codex_home().join("skills/chat-history"), "Codex"),
-    ]
-}
-
-fn write_skill(dir: &std::path::Path) -> bool {
-    if std::fs::create_dir_all(dir).is_err() {
-        return false;
-    }
-    std::fs::write(dir.join("SKILL.md"), SKILL_CONTENT).is_ok()
-}
-
-fn install_skill() {
-    let targets = skill_targets();
-    if targets.is_empty() {
-        eprintln!("Could not determine home directory");
-        std::process::exit(1);
-    }
-
-    let mut any_installed = false;
-    for (dir, name) in &targets {
-        if write_skill(dir) {
-            println!("  installed → {}", dir.join("SKILL.md").display());
-            any_installed = true;
-        } else {
-            eprintln!("  skip {name}: could not write to {}", dir.display());
-        }
-    }
-
-    if any_installed {
-        println!("\nDone. The skill is active immediately — no restart needed.");
-    } else {
-        eprintln!("\nNo skills were installed.");
-        std::process::exit(1);
-    }
+    InstallSkill {
+        /// Overwrite existing skills even if they were user-edited
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 fn parse_date_arg(val: &Option<String>) -> Option<chrono::NaiveDate> {
@@ -172,10 +131,14 @@ fn main() {
 
     let cli = Cli::parse();
 
-    if matches!(cli.command, Some(Commands::InstallSkill)) {
-        install_skill();
+    if let Some(Commands::InstallSkill { force }) = &cli.command {
+        install_skill(*force);
         return;
     }
+
+    // Auto-install / refresh managed agent skills on first use (and later
+    // upgrades). Never overwrites user-edited skills.
+    ensure_skills();
 
     let mut sessions = load_all_sessions();
     if !cli.sidechains {
@@ -364,7 +327,7 @@ fn main() {
             };
             println!("{}", session.file);
         }
-        Some(Commands::InstallSkill) => unreachable!(),
+        Some(Commands::InstallSkill { .. }) => unreachable!(),
         None => {
             if cli.summarize {
                 display::print_summarized(&filtered);

--- a/src/session.rs
+++ b/src/session.rs
@@ -91,7 +91,10 @@ fn home_dir() -> PathBuf {
 }
 
 fn dirs_next() -> Option<PathBuf> {
-    std::env::var_os("HOME").map(PathBuf::from)
+    // macOS/Linux use HOME; Windows typically uses USERPROFILE.
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
 }
 
 pub fn claude_projects_dir() -> PathBuf {

--- a/src/session.rs
+++ b/src/session.rs
@@ -87,11 +87,11 @@ struct IndexEntry {
 }
 
 fn home_dir() -> PathBuf {
-    dirs_next().unwrap_or_else(|| PathBuf::from("."))
+    user_home().unwrap_or_else(|| PathBuf::from("."))
 }
 
-fn dirs_next() -> Option<PathBuf> {
-    // macOS/Linux use HOME; Windows typically uses USERPROFILE.
+/// Resolve the user home directory (macOS/Linux `HOME`, Windows `USERPROFILE`).
+pub fn user_home() -> Option<PathBuf> {
     std::env::var_os("HOME")
         .or_else(|| std::env::var_os("USERPROFILE"))
         .map(PathBuf::from)

--- a/src/skill_install.rs
+++ b/src/skill_install.rs
@@ -10,9 +10,7 @@ pub const MANAGED_SIDECAR: &str = ".chat-history-managed";
 
 /// Resolve the user home directory (macOS/Linux `HOME`, Windows `USERPROFILE`).
 pub fn user_home() -> Option<PathBuf> {
-    std::env::var_os("HOME")
-        .or_else(|| std::env::var_os("USERPROFILE"))
-        .map(PathBuf::from)
+    session::user_home()
 }
 
 /// Stable content fingerprint for managed-skill detection (FNV-1a 64-bit).
@@ -36,12 +34,13 @@ fn skill_path(dir: &Path) -> PathBuf {
 /// Target skill directories for Cursor, Claude Code, and Codex.
 pub fn skill_targets() -> Vec<(PathBuf, &'static str)> {
     let mut targets = Vec::new();
-    if let Some(home) = user_home() {
+    let home = user_home();
+    if let Some(ref home) = home {
         targets.push((home.join(".cursor/skills/chat-history"), "Cursor"));
         targets.push((home.join(".claude/skills/chat-history"), "Claude Code"));
     }
     // Codex: CODEX_HOME, or home-derived ~/.codex when home is known.
-    if std::env::var_os("CODEX_HOME").is_some() || user_home().is_some() {
+    if std::env::var_os("CODEX_HOME").is_some() || home.is_some() {
         targets.push((session::codex_home().join("skills/chat-history"), "Codex"));
     }
     targets
@@ -59,19 +58,34 @@ fn write_managed_skill(dir: &Path) -> bool {
     std::fs::write(&sidecar, content_hash(SKILL_CONTENT)).is_ok()
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Mode {
+    /// Silent auto-path: never overwrite user edits or ambiguous legacy copies.
+    Quiet,
+    /// `install-skill`: refresh managed + adopt sidecar-less legacy; keep user edits.
+    Explicit,
+    /// `install-skill --force`: overwrite everything.
+    Force,
+}
+
+#[derive(Debug, PartialEq, Eq)]
 enum EnsureAction {
     Wrote,
     Refreshed,
-    Skipped,
+    AlreadyCurrent,
+    /// Sidecar present but content hash no longer matches — treat as user edit.
+    LeftUserEdited,
+    /// Sidecar-less copy that differs from embedded (quiet path only).
+    LeftLegacy,
     Failed,
 }
 
-fn ensure_one(dir: &Path, force: bool) -> EnsureAction {
+fn ensure_one(dir: &Path, mode: Mode) -> EnsureAction {
     let skill = skill_path(dir);
     let sidecar = sidecar_path(dir);
     let embedded_hash = content_hash(SKILL_CONTENT);
 
-    if force {
+    if mode == Mode::Force {
         return if write_managed_skill(dir) {
             EnsureAction::Wrote
         } else {
@@ -96,7 +110,7 @@ fn ensure_one(dir: &Path, force: bool) -> EnsureAction {
                     if managed == on_disk_hash {
                         // Still our copy. Refresh if embedded skill changed.
                         if on_disk_hash == embedded_hash {
-                            EnsureAction::Skipped
+                            EnsureAction::AlreadyCurrent
                         } else if write_managed_skill(dir) {
                             EnsureAction::Refreshed
                         } else {
@@ -104,18 +118,26 @@ fn ensure_one(dir: &Path, force: bool) -> EnsureAction {
                         }
                     } else {
                         // Sidecar present but content changed → user-edited.
-                        EnsureAction::Skipped
+                        EnsureAction::LeftUserEdited
                     }
                 }
                 Err(_) => {
-                    // Legacy install (no sidecar). Adopt only if it already
-                    // matches the current embedded skill; never overwrite edits
-                    // or older defaults we can't prove are ours.
+                    // Legacy install (no sidecar).
                     if on_disk_hash == embedded_hash {
-                        let _ = std::fs::write(&sidecar, embedded_hash);
-                        EnsureAction::Skipped
+                        let _ = std::fs::write(&sidecar, &embedded_hash);
+                        EnsureAction::AlreadyCurrent
+                    } else if mode == Mode::Explicit {
+                        // Explicit install-skill: adopt pre-sidecar installs so
+                        // upgrades that re-run install-skill get the new skill
+                        // (matches 0.2.x "re-run install-skill after upgrades").
+                        if write_managed_skill(dir) {
+                            EnsureAction::Refreshed
+                        } else {
+                            EnsureAction::Failed
+                        }
                     } else {
-                        EnsureAction::Skipped
+                        // Quiet path: don't guess — leave alone.
+                        EnsureAction::LeftLegacy
                     }
                 }
             }
@@ -124,16 +146,17 @@ fn ensure_one(dir: &Path, force: bool) -> EnsureAction {
 }
 
 /// Quietly install or refresh managed skills. Never prints; never overwrites
-/// user-edited skills. Safe to call on every CLI invocation.
+/// user-edited or ambiguous legacy skills. Safe to call on every CLI invocation.
 pub fn ensure_skills() {
     for (dir, _) in skill_targets() {
-        let _ = ensure_one(&dir, false);
+        let _ = ensure_one(&dir, Mode::Quiet);
     }
 }
 
 /// Explicit install used by `chat-history install-skill`.
 ///
-/// Without `force`, same rules as [`ensure_skills`] but reports what happened.
+/// Without `force`, refreshes managed copies and adopts sidecar-less legacy
+/// installs, but leaves verified user edits alone (prints a `--force` hint).
 /// With `force`, overwrites even user-edited skills.
 pub fn install_skill(force: bool) {
     let targets = skill_targets();
@@ -142,9 +165,10 @@ pub fn install_skill(force: bool) {
         std::process::exit(1);
     }
 
+    let mode = if force { Mode::Force } else { Mode::Explicit };
     let mut any_ok = false;
     for (dir, name) in &targets {
-        match ensure_one(dir, force) {
+        match ensure_one(dir, mode) {
             EnsureAction::Wrote => {
                 println!("  installed → {}", skill_path(dir).display());
                 any_ok = true;
@@ -153,13 +177,24 @@ pub fn install_skill(force: bool) {
                 println!("  refreshed → {}", skill_path(dir).display());
                 any_ok = true;
             }
-            EnsureAction::Skipped => {
-                if skill_path(dir).exists() {
-                    println!("  unchanged → {}", skill_path(dir).display());
-                    any_ok = true;
-                } else {
-                    eprintln!("  skip {name}: could not write to {}", dir.display());
-                }
+            EnsureAction::AlreadyCurrent => {
+                println!("  already current → {}", skill_path(dir).display());
+                any_ok = true;
+            }
+            EnsureAction::LeftUserEdited => {
+                println!(
+                    "  left alone → {} (user-edited; use --force to overwrite)",
+                    skill_path(dir).display()
+                );
+                any_ok = true;
+            }
+            EnsureAction::LeftLegacy => {
+                // Only reachable in Quiet mode; keep arm for exhaustiveness.
+                println!(
+                    "  left alone → {} (not managed; use --force to overwrite)",
+                    skill_path(dir).display()
+                );
+                any_ok = true;
             }
             EnsureAction::Failed => {
                 eprintln!("  skip {name}: could not write to {}", dir.display());
@@ -181,7 +216,7 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
-    fn with_home<F: FnOnce(&Path)>(f: F) {
+    fn with_tmp<F: FnOnce(&Path)>(f: F) {
         let tmp = TempDir::new().unwrap();
         f(tmp.path());
     }
@@ -194,9 +229,9 @@ mod tests {
 
     #[test]
     fn writes_when_missing() {
-        with_home(|home| {
+        with_tmp(|home| {
             let dir = home.join(".claude/skills/chat-history");
-            assert!(matches!(ensure_one(&dir, false), EnsureAction::Wrote));
+            assert!(matches!(ensure_one(&dir, Mode::Quiet), EnsureAction::Wrote));
             assert_eq!(fs::read_to_string(skill_path(&dir)).unwrap(), SKILL_CONTENT);
             assert_eq!(
                 fs::read_to_string(sidecar_path(&dir)).unwrap(),
@@ -207,24 +242,34 @@ mod tests {
 
     #[test]
     fn refreshes_managed_stale_copy() {
-        with_home(|home| {
+        with_tmp(|home| {
             let dir = home.join(".claude/skills/chat-history");
             fs::create_dir_all(&dir).unwrap();
             fs::write(skill_path(&dir), "old default").unwrap();
             fs::write(sidecar_path(&dir), content_hash("old default")).unwrap();
-            assert!(matches!(ensure_one(&dir, false), EnsureAction::Refreshed));
+            assert!(matches!(
+                ensure_one(&dir, Mode::Quiet),
+                EnsureAction::Refreshed
+            ));
             assert_eq!(fs::read_to_string(skill_path(&dir)).unwrap(), SKILL_CONTENT);
         });
     }
 
     #[test]
     fn preserves_user_edits() {
-        with_home(|home| {
+        with_tmp(|home| {
             let dir = home.join(".claude/skills/chat-history");
             fs::create_dir_all(&dir).unwrap();
             fs::write(skill_path(&dir), "my custom skill").unwrap();
             fs::write(sidecar_path(&dir), content_hash("old default")).unwrap();
-            assert!(matches!(ensure_one(&dir, false), EnsureAction::Skipped));
+            assert!(matches!(
+                ensure_one(&dir, Mode::Quiet),
+                EnsureAction::LeftUserEdited
+            ));
+            assert!(matches!(
+                ensure_one(&dir, Mode::Explicit),
+                EnsureAction::LeftUserEdited
+            ));
             assert_eq!(
                 fs::read_to_string(skill_path(&dir)).unwrap(),
                 "my custom skill"
@@ -233,12 +278,15 @@ mod tests {
     }
 
     #[test]
-    fn preserves_legacy_without_sidecar() {
-        with_home(|home| {
+    fn quiet_preserves_legacy_without_sidecar() {
+        with_tmp(|home| {
             let dir = home.join(".claude/skills/chat-history");
             fs::create_dir_all(&dir).unwrap();
             fs::write(skill_path(&dir), "legacy custom").unwrap();
-            assert!(matches!(ensure_one(&dir, false), EnsureAction::Skipped));
+            assert!(matches!(
+                ensure_one(&dir, Mode::Quiet),
+                EnsureAction::LeftLegacy
+            ));
             assert_eq!(
                 fs::read_to_string(skill_path(&dir)).unwrap(),
                 "legacy custom"
@@ -248,23 +296,44 @@ mod tests {
     }
 
     #[test]
+    fn explicit_adopts_legacy_without_sidecar() {
+        with_tmp(|home| {
+            let dir = home.join(".claude/skills/chat-history");
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(skill_path(&dir), "legacy 0.2.x skill").unwrap();
+            assert!(matches!(
+                ensure_one(&dir, Mode::Explicit),
+                EnsureAction::Refreshed
+            ));
+            assert_eq!(fs::read_to_string(skill_path(&dir)).unwrap(), SKILL_CONTENT);
+            assert_eq!(
+                fs::read_to_string(sidecar_path(&dir)).unwrap(),
+                content_hash(SKILL_CONTENT)
+            );
+        });
+    }
+
+    #[test]
     fn force_overwrites_user_edits() {
-        with_home(|home| {
+        with_tmp(|home| {
             let dir = home.join(".claude/skills/chat-history");
             fs::create_dir_all(&dir).unwrap();
             fs::write(skill_path(&dir), "my custom skill").unwrap();
-            assert!(matches!(ensure_one(&dir, true), EnsureAction::Wrote));
+            assert!(matches!(ensure_one(&dir, Mode::Force), EnsureAction::Wrote));
             assert_eq!(fs::read_to_string(skill_path(&dir)).unwrap(), SKILL_CONTENT);
         });
     }
 
     #[test]
     fn adopts_legacy_matching_embedded() {
-        with_home(|home| {
+        with_tmp(|home| {
             let dir = home.join(".claude/skills/chat-history");
             fs::create_dir_all(&dir).unwrap();
             fs::write(skill_path(&dir), SKILL_CONTENT).unwrap();
-            assert!(matches!(ensure_one(&dir, false), EnsureAction::Skipped));
+            assert!(matches!(
+                ensure_one(&dir, Mode::Quiet),
+                EnsureAction::AlreadyCurrent
+            ));
             assert_eq!(
                 fs::read_to_string(sidecar_path(&dir)).unwrap(),
                 content_hash(SKILL_CONTENT)

--- a/src/skill_install.rs
+++ b/src/skill_install.rs
@@ -1,0 +1,274 @@
+use std::path::{Path, PathBuf};
+
+use crate::session;
+
+/// Bundled agent skill (Claude Code / Cursor / Codex).
+pub const SKILL_CONTENT: &str = include_str!("../SKILL.md");
+
+/// Sidecar next to SKILL.md marking a copy we installed and may refresh.
+pub const MANAGED_SIDECAR: &str = ".chat-history-managed";
+
+/// Resolve the user home directory (macOS/Linux `HOME`, Windows `USERPROFILE`).
+pub fn user_home() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+/// Stable content fingerprint for managed-skill detection (FNV-1a 64-bit).
+pub fn content_hash(content: &str) -> String {
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for b in content.as_bytes() {
+        hash ^= u64::from(*b);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}")
+}
+
+fn sidecar_path(dir: &Path) -> PathBuf {
+    dir.join(MANAGED_SIDECAR)
+}
+
+fn skill_path(dir: &Path) -> PathBuf {
+    dir.join("SKILL.md")
+}
+
+/// Target skill directories for Cursor, Claude Code, and Codex.
+pub fn skill_targets() -> Vec<(PathBuf, &'static str)> {
+    let mut targets = Vec::new();
+    if let Some(home) = user_home() {
+        targets.push((home.join(".cursor/skills/chat-history"), "Cursor"));
+        targets.push((home.join(".claude/skills/chat-history"), "Claude Code"));
+    }
+    // Codex: CODEX_HOME, or home-derived ~/.codex when home is known.
+    if std::env::var_os("CODEX_HOME").is_some() || user_home().is_some() {
+        targets.push((session::codex_home().join("skills/chat-history"), "Codex"));
+    }
+    targets
+}
+
+fn write_managed_skill(dir: &Path) -> bool {
+    if std::fs::create_dir_all(dir).is_err() {
+        return false;
+    }
+    let skill = skill_path(dir);
+    let sidecar = sidecar_path(dir);
+    if std::fs::write(&skill, SKILL_CONTENT).is_err() {
+        return false;
+    }
+    std::fs::write(&sidecar, content_hash(SKILL_CONTENT)).is_ok()
+}
+
+enum EnsureAction {
+    Wrote,
+    Refreshed,
+    Skipped,
+    Failed,
+}
+
+fn ensure_one(dir: &Path, force: bool) -> EnsureAction {
+    let skill = skill_path(dir);
+    let sidecar = sidecar_path(dir);
+    let embedded_hash = content_hash(SKILL_CONTENT);
+
+    if force {
+        return if write_managed_skill(dir) {
+            EnsureAction::Wrote
+        } else {
+            EnsureAction::Failed
+        };
+    }
+
+    match std::fs::read_to_string(&skill) {
+        Err(_) => {
+            // Missing (or unreadable) → install.
+            if write_managed_skill(dir) {
+                EnsureAction::Wrote
+            } else {
+                EnsureAction::Failed
+            }
+        }
+        Ok(on_disk) => {
+            let on_disk_hash = content_hash(&on_disk);
+            match std::fs::read_to_string(&sidecar) {
+                Ok(managed) => {
+                    let managed = managed.trim();
+                    if managed == on_disk_hash {
+                        // Still our copy. Refresh if embedded skill changed.
+                        if on_disk_hash == embedded_hash {
+                            EnsureAction::Skipped
+                        } else if write_managed_skill(dir) {
+                            EnsureAction::Refreshed
+                        } else {
+                            EnsureAction::Failed
+                        }
+                    } else {
+                        // Sidecar present but content changed → user-edited.
+                        EnsureAction::Skipped
+                    }
+                }
+                Err(_) => {
+                    // Legacy install (no sidecar). Adopt only if it already
+                    // matches the current embedded skill; never overwrite edits
+                    // or older defaults we can't prove are ours.
+                    if on_disk_hash == embedded_hash {
+                        let _ = std::fs::write(&sidecar, embedded_hash);
+                        EnsureAction::Skipped
+                    } else {
+                        EnsureAction::Skipped
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Quietly install or refresh managed skills. Never prints; never overwrites
+/// user-edited skills. Safe to call on every CLI invocation.
+pub fn ensure_skills() {
+    for (dir, _) in skill_targets() {
+        let _ = ensure_one(&dir, false);
+    }
+}
+
+/// Explicit install used by `chat-history install-skill`.
+///
+/// Without `force`, same rules as [`ensure_skills`] but reports what happened.
+/// With `force`, overwrites even user-edited skills.
+pub fn install_skill(force: bool) {
+    let targets = skill_targets();
+    if targets.is_empty() {
+        eprintln!("Could not determine home directory (set HOME or USERPROFILE)");
+        std::process::exit(1);
+    }
+
+    let mut any_ok = false;
+    for (dir, name) in &targets {
+        match ensure_one(dir, force) {
+            EnsureAction::Wrote => {
+                println!("  installed → {}", skill_path(dir).display());
+                any_ok = true;
+            }
+            EnsureAction::Refreshed => {
+                println!("  refreshed → {}", skill_path(dir).display());
+                any_ok = true;
+            }
+            EnsureAction::Skipped => {
+                if skill_path(dir).exists() {
+                    println!("  unchanged → {}", skill_path(dir).display());
+                    any_ok = true;
+                } else {
+                    eprintln!("  skip {name}: could not write to {}", dir.display());
+                }
+            }
+            EnsureAction::Failed => {
+                eprintln!("  skip {name}: could not write to {}", dir.display());
+            }
+        }
+    }
+
+    if any_ok {
+        println!("\nDone. The skill is active immediately — no restart needed.");
+    } else {
+        eprintln!("\nNo skills were installed.");
+        std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn with_home<F: FnOnce(&Path)>(f: F) {
+        let tmp = TempDir::new().unwrap();
+        f(tmp.path());
+    }
+
+    #[test]
+    fn content_hash_stable() {
+        assert_eq!(content_hash("abc"), content_hash("abc"));
+        assert_ne!(content_hash("abc"), content_hash("abd"));
+    }
+
+    #[test]
+    fn writes_when_missing() {
+        with_home(|home| {
+            let dir = home.join(".claude/skills/chat-history");
+            assert!(matches!(ensure_one(&dir, false), EnsureAction::Wrote));
+            assert_eq!(fs::read_to_string(skill_path(&dir)).unwrap(), SKILL_CONTENT);
+            assert_eq!(
+                fs::read_to_string(sidecar_path(&dir)).unwrap(),
+                content_hash(SKILL_CONTENT)
+            );
+        });
+    }
+
+    #[test]
+    fn refreshes_managed_stale_copy() {
+        with_home(|home| {
+            let dir = home.join(".claude/skills/chat-history");
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(skill_path(&dir), "old default").unwrap();
+            fs::write(sidecar_path(&dir), content_hash("old default")).unwrap();
+            assert!(matches!(ensure_one(&dir, false), EnsureAction::Refreshed));
+            assert_eq!(fs::read_to_string(skill_path(&dir)).unwrap(), SKILL_CONTENT);
+        });
+    }
+
+    #[test]
+    fn preserves_user_edits() {
+        with_home(|home| {
+            let dir = home.join(".claude/skills/chat-history");
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(skill_path(&dir), "my custom skill").unwrap();
+            fs::write(sidecar_path(&dir), content_hash("old default")).unwrap();
+            assert!(matches!(ensure_one(&dir, false), EnsureAction::Skipped));
+            assert_eq!(
+                fs::read_to_string(skill_path(&dir)).unwrap(),
+                "my custom skill"
+            );
+        });
+    }
+
+    #[test]
+    fn preserves_legacy_without_sidecar() {
+        with_home(|home| {
+            let dir = home.join(".claude/skills/chat-history");
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(skill_path(&dir), "legacy custom").unwrap();
+            assert!(matches!(ensure_one(&dir, false), EnsureAction::Skipped));
+            assert_eq!(
+                fs::read_to_string(skill_path(&dir)).unwrap(),
+                "legacy custom"
+            );
+            assert!(!sidecar_path(&dir).exists());
+        });
+    }
+
+    #[test]
+    fn force_overwrites_user_edits() {
+        with_home(|home| {
+            let dir = home.join(".claude/skills/chat-history");
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(skill_path(&dir), "my custom skill").unwrap();
+            assert!(matches!(ensure_one(&dir, true), EnsureAction::Wrote));
+            assert_eq!(fs::read_to_string(skill_path(&dir)).unwrap(), SKILL_CONTENT);
+        });
+    }
+
+    #[test]
+    fn adopts_legacy_matching_embedded() {
+        with_home(|home| {
+            let dir = home.join(".claude/skills/chat-history");
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(skill_path(&dir), SKILL_CONTENT).unwrap();
+            assert!(matches!(ensure_one(&dir, false), EnsureAction::Skipped));
+            assert_eq!(
+                fs::read_to_string(sidecar_path(&dir)).unwrap(),
+                content_hash(SKILL_CONTENT)
+            );
+        });
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -89,6 +89,7 @@ fn install_skill_creates_files() {
         .unwrap()
         .arg("install-skill")
         .env("HOME", tmp.path())
+        .env_remove("USERPROFILE")
         .env_remove("CODEX_HOME")
         .assert()
         .success()
@@ -100,12 +101,102 @@ fn install_skill_creates_files() {
     );
     assert!(
         tmp.path()
+            .join(".claude/skills/chat-history/.chat-history-managed")
+            .exists()
+    );
+    assert!(
+        tmp.path()
             .join(".cursor/skills/chat-history/SKILL.md")
             .exists()
     );
     assert!(
         tmp.path()
             .join(".codex/skills/chat-history/SKILL.md")
+            .exists()
+    );
+}
+
+#[test]
+fn ensure_skills_runs_on_normal_invocation() {
+    let tmp = TempDir::new().unwrap();
+    Command::cargo_bin("chat-history")
+        .unwrap()
+        .env("HOME", tmp.path())
+        .env_remove("USERPROFILE")
+        .env_remove("CODEX_HOME")
+        .assert()
+        .success();
+    assert!(
+        tmp.path()
+            .join(".claude/skills/chat-history/SKILL.md")
+            .exists()
+    );
+    assert!(
+        tmp.path()
+            .join(".claude/skills/chat-history/.chat-history-managed")
+            .exists()
+    );
+}
+
+#[test]
+fn ensure_skills_preserves_user_edits() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().join(".claude/skills/chat-history");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("SKILL.md"), "user customized skill").unwrap();
+    fs::write(dir.join(".chat-history-managed"), "deadbeefdeadbeef").unwrap();
+
+    Command::cargo_bin("chat-history")
+        .unwrap()
+        .env("HOME", tmp.path())
+        .env_remove("USERPROFILE")
+        .env_remove("CODEX_HOME")
+        .assert()
+        .success();
+
+    assert_eq!(
+        fs::read_to_string(dir.join("SKILL.md")).unwrap(),
+        "user customized skill"
+    );
+}
+
+#[test]
+fn install_skill_force_overwrites_user_edits() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().join(".claude/skills/chat-history");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("SKILL.md"), "user customized skill").unwrap();
+
+    Command::cargo_bin("chat-history")
+        .unwrap()
+        .args(["install-skill", "--force"])
+        .env("HOME", tmp.path())
+        .env_remove("USERPROFILE")
+        .env_remove("CODEX_HOME")
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(dir.join("SKILL.md")).unwrap();
+    assert_ne!(content, "user customized skill");
+    assert!(content.contains("chat-history"));
+    assert!(dir.join(".chat-history-managed").exists());
+}
+
+#[test]
+fn skill_targets_honor_userprofile_without_home() {
+    let tmp = TempDir::new().unwrap();
+    Command::cargo_bin("chat-history")
+        .unwrap()
+        .arg("install-skill")
+        .env_remove("HOME")
+        .env("USERPROFILE", tmp.path())
+        .env_remove("CODEX_HOME")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("installed"));
+    assert!(
+        tmp.path()
+            .join(".claude/skills/chat-history/SKILL.md")
             .exists()
     );
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -161,6 +161,54 @@ fn ensure_skills_preserves_user_edits() {
 }
 
 #[test]
+fn install_skill_adopts_legacy_without_sidecar() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().join(".claude/skills/chat-history");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("SKILL.md"), "legacy 0.2.x skill without sidecar").unwrap();
+
+    Command::cargo_bin("chat-history")
+        .unwrap()
+        .arg("install-skill")
+        .env("HOME", tmp.path())
+        .env_remove("USERPROFILE")
+        .env_remove("CODEX_HOME")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("refreshed"));
+
+    let content = fs::read_to_string(dir.join("SKILL.md")).unwrap();
+    assert_ne!(content, "legacy 0.2.x skill without sidecar");
+    assert!(content.contains("chat-history"));
+    assert!(dir.join(".chat-history-managed").exists());
+}
+
+#[test]
+fn install_skill_hints_on_user_edited() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().join(".claude/skills/chat-history");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("SKILL.md"), "user customized skill").unwrap();
+    fs::write(dir.join(".chat-history-managed"), "deadbeefdeadbeef").unwrap();
+
+    Command::cargo_bin("chat-history")
+        .unwrap()
+        .arg("install-skill")
+        .env("HOME", tmp.path())
+        .env_remove("USERPROFILE")
+        .env_remove("CODEX_HOME")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("user-edited"))
+        .stdout(predicate::str::contains("--force"));
+
+    assert_eq!(
+        fs::read_to_string(dir.join("SKILL.md")).unwrap(),
+        "user customized skill"
+    );
+}
+
+#[test]
 fn install_skill_force_overwrites_user_edits() {
     let tmp = TempDir::new().unwrap();
     let dir = tmp.path().join(".claude/skills/chat-history");


### PR DESCRIPTION
## Summary

- **Auto-install/refresh the bundled agent skill** on every `chat-history` / `ch` run, tracked by a `.chat-history-managed` content-hash sidecar so upgrades refresh our copies without clobbering user edits.
- **Three install modes** (`src/skill_install.rs`):
  - *Quiet auto-path* (every run): missing → install; managed + stale → refresh; user-edited or ambiguous legacy → leave alone, silently.
  - *Explicit `install-skill`*: same, plus adopts sidecar-less pre-0.3 installs (so the documented "re-run after upgrade" flow works); user-edited copies are kept with a `use --force to overwrite` hint.
  - *`install-skill --force`*: overwrites everything.
- **Rewrite `SKILL.md` from a command catalog into a workflow skill**, every claim verified against the CLI/source and A/B-tested with paired subagents:
  - Process sections for the two real flows: keyword search (`search … --deep --json` → shortlist by snippet → `inspect` 2–3 candidates) and temporal questions (list with `--from X --to X -v`, don't search).
  - Documents verified pitfalls: `--from X` alone means *X through today*; the grouped `-s` view hides session IDs even with `-v`; `--json` exists only on `search`; scores rank keyword density, not intent; the current conversation can self-match its own query.
  - Documents all five `--scope` values and the shared filter flags; trims install/repo prose from the always-loaded body.
- Resolve home as `HOME` then `USERPROFILE` (Windows), shared via one `user_home()` helper.

## Test plan

- [x] `cargo test` — 171 unit + 73 integration tests pass
- [x] `cargo install --path .` (0.1.9 → 0.2.0), then verified with the installed binary in a sandbox `HOME`: fresh run auto-installs skill + sidecar; quiet path preserves a user-edited `SKILL.md`; explicit `install-skill` keeps the edit and prints the `--force` hint; `--force` overwrites; managed-but-stale copy is quietly refreshed on a plain run (the future-upgrade path)
- [x] Real-machine legacy upgrade: pre-sidecar copies in `~/.claude|.cursor|.codex/skills/chat-history/` were left untouched by a plain run and adopted (refreshed + sidecar written) by `install-skill`
- [x] Functional smoke test with the new binary: session list, `search --deep --json`, `inspect --last`
- [x] A/B subagent evaluation of the rewritten skill vs the old one (temporal, ranking, and machine-readable-output tasks): first-action correctness on temporal queries improved; no regressions observed
- [ ] Windows `USERPROFILE`-only environment (covered by integration test `skill_targets_honor_userprofile_without_home`; not manually verified on Windows)