### PR TITLE
Readable rows: short session IDs everywhere and single-line titles

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -25,9 +25,9 @@ Search, inspect, and export Claude Code, Cursor, and Codex conversation history.
 
 **Temporal question** ("what did I work on yesterday?") — list, don't search:
 
-1. `chat-history --from yesterday --to yesterday -v` — `-v` shows session IDs.
+1. `chat-history --from yesterday --to yesterday` — every row shows a short session ID; `-s` groups by day for multi-day overviews.
    - `--from X` alone means **X through today**. Always pair with `--to` when the user means a specific day.
-   - `-s` groups by day for multi-day overviews, but the grouped view hides session IDs even with `-v` — use the flat `-v` list when you need IDs.
+   - Short IDs work everywhere a session ID is accepted (`inspect`, `view`, `resume`, `find`); `-v` adds full IDs and file paths.
 2. `chat-history inspect <id>` for accomplishments, tools, files touched.
 
 ## Choosing the best hit
@@ -39,7 +39,6 @@ Search, inspect, and export Claude Code, Cursor, and Codex conversation history.
 ## Common mistakes
 
 - Only `search` accepts `--json`; the session list and `inspect` reject it.
-- The session list shows no IDs unless you pass `-v`.
 - The only subcommands are `search`, `inspect`, `view`, `export`, `resume`, `find`, `install-skill`. Do not guess others; run `chat-history --help` when unsure.
 - Don't dump raw JSON or full transcripts at the user — summarize, cite the session ID and date.
 - Some Cursor sessions have thin metadata (`(no summary)`, `duration: 0min`, raw first-message titles). If `inspect` is thin, fall back to `chat-history view <id> --plain`.
@@ -48,7 +47,7 @@ Search, inspect, and export Claude Code, Cursor, and Codex conversation history.
 
 ```bash
 # List sessions
-chat-history                                      # newest first (-v for IDs and paths)
+chat-history                                      # newest first; short IDs on every row (-v for full IDs + paths)
 chat-history --from yesterday --to yesterday -s   # a specific day, grouped
 chat-history --from "3 days ago"                  # natural-language dates
 chat-history --source claude                      # claude | cursor | codex

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,5 +1,5 @@
 use crate::inspect::InspectInfo;
-use crate::parser::{clean_prompt, snippet_around_match};
+use crate::parser::{clean_prompt, display_title, snippet_around_match};
 use crate::search::{IndexResult, SearchResult};
 use crate::session::{Message, Session};
 use std::collections::BTreeMap;
@@ -41,6 +41,26 @@ fn src_tag(source: &str) -> String {
     }
 }
 
+/// Dim 8-char session-id chip. Every prefix resolves via `inspect`/`view`/
+/// `resume`/`find`, so each row carries its own address.
+fn id_chip(id: &str) -> String {
+    let short: String = id.chars().take(8).collect();
+    format!("{}{:8}{}", c!("dim"), short, c!("reset"))
+}
+
+/// Best one-line title for a session: summary, else cleaned first prompt.
+fn title_of(summary: &str, first_prompt: &str, max: usize) -> String {
+    let t = display_title(summary, max);
+    if !t.is_empty() {
+        return t;
+    }
+    let t = display_title(first_prompt, max);
+    if !t.is_empty() {
+        return t;
+    }
+    "(untitled)".into()
+}
+
 pub fn print_list(sessions: &[Session], verbose: bool) {
     if sessions.is_empty() {
         println!("{}No sessions found.{}", c!("dim"), c!("reset"));
@@ -54,16 +74,7 @@ pub fn print_list(sessions: &[Session], verbose: bool) {
     );
     for (i, s) in sessions.iter().enumerate() {
         let tag = src_tag(&s.source);
-        let summary = if !s.summary.is_empty() {
-            s.summary.chars().take(100).collect::<String>()
-        } else if !s.first_prompt.is_empty() {
-            clean_prompt(&s.first_prompt)
-                .chars()
-                .take(100)
-                .collect::<String>()
-        } else {
-            "(empty)".into()
-        };
+        let title = title_of(&s.summary, &s.first_prompt, 72);
         let branch = if s.branch.is_empty() {
             String::new()
         } else {
@@ -80,7 +91,7 @@ pub fn print_list(sessions: &[Session], verbose: bool) {
             String::new()
         };
         println!(
-            "  {}{:3}.{} {} {}{}{}  {}{}{}{}{}{}",
+            "  {}{:3}.{} {} {}{}{}  {}  {}{}{}{}{}{}",
             c!("dim"),
             i + 1,
             c!("reset"),
@@ -88,8 +99,9 @@ pub fn print_list(sessions: &[Session], verbose: bool) {
             c!("cyan"),
             s.date,
             c!("reset"),
+            id_chip(&s.id),
             c!("bold"),
-            summary,
+            title,
             c!("reset"),
             sidechain,
             branch,
@@ -131,22 +143,19 @@ pub fn print_summarized(sessions: &[Session]) {
             c!("reset")
         );
         for s in ds {
-            let title = if !s.summary.is_empty() {
-                s.summary.chars().take(80).collect::<String>()
-            } else if !s.first_prompt.is_empty() {
-                clean_prompt(&s.first_prompt)
-                    .chars()
-                    .take(80)
-                    .collect::<String>()
-            } else {
-                "(empty)".into()
-            };
+            let title = title_of(&s.summary, &s.first_prompt, 72);
             let branch = if s.branch.is_empty() {
                 String::new()
             } else {
                 format!(" {}({}){}", c!("magenta"), s.branch, c!("reset"))
             };
-            println!("    {} {}{}", src_tag(&s.source), title, branch);
+            println!(
+                "    {} {}  {}{}",
+                src_tag(&s.source),
+                id_chip(&s.id),
+                title,
+                branch
+            );
         }
         println!();
     }
@@ -170,19 +179,14 @@ pub fn print_index_results(results: &[IndexResult], query: &str) {
         let tag = src_tag(&r.session.source);
         let score = format!("{}★ {:.1}{}", c!("yellow"), r.score, c!("reset"));
         let field = format!("{} [{}]{}", c!("dim"), r.matched_field, c!("reset"));
-        let summary_or_display = if !r.session.summary.is_empty() {
-            r.session.summary.chars().take(80).collect::<String>()
-        } else {
-            r.display.chars().take(80).collect::<String>()
-        };
-        let sid_short: String = r.session.id.chars().take(8).collect();
+        let title = title_of(&r.session.summary, &r.display, 72);
         let branch = if r.session.branch.is_empty() {
             String::new()
         } else {
             format!(" {}({}){}", c!("magenta"), r.session.branch, c!("reset"))
         };
         println!(
-            "  {}{:3}.{} {} {}{}{} {}{} {}{}{}{}  {}[{}]{}",
+            "  {}{:3}.{} {} {}{}{} {} {}{} {}{}{}{}",
             c!("dim"),
             i + 1,
             c!("reset"),
@@ -190,15 +194,13 @@ pub fn print_index_results(results: &[IndexResult], query: &str) {
             c!("cyan"),
             r.session.date,
             c!("reset"),
+            id_chip(&r.session.id),
             score,
             field,
             c!("bold"),
-            summary_or_display,
+            title,
             c!("reset"),
-            branch,
-            c!("dim"),
-            sid_short,
-            c!("reset")
+            branch
         );
     }
     println!();
@@ -224,24 +226,14 @@ pub fn print_search_results(results: &[SearchResult], query: &str) {
             r.message.final_score,
             c!("reset")
         );
-        let sid_short: String = r.session.id.chars().take(8).collect();
         let role_str = if r.message.role == "user" {
             format!("{}You{}", c!("green"), c!("reset"))
         } else {
             format!("{}Assistant{}", c!("blue"), c!("reset"))
         };
-        let display_title = if !r.session.summary.is_empty() {
-            r.session.summary.chars().take(80).collect::<String>()
-        } else if !r.session.first_prompt.is_empty() {
-            clean_prompt(&r.session.first_prompt)
-                .chars()
-                .take(80)
-                .collect::<String>()
-        } else {
-            "(no summary)".into()
-        };
+        let title = title_of(&r.session.summary, &r.session.first_prompt, 72);
         println!(
-            "  {}{:3}.{} {} {}{}{} {}  {}{}{}  {}[{}]{}",
+            "  {}{:3}.{} {} {}{}{} {} {}  {}{}{}",
             c!("dim"),
             i + 1,
             c!("reset"),
@@ -249,12 +241,10 @@ pub fn print_search_results(results: &[SearchResult], query: &str) {
             c!("cyan"),
             r.session.date,
             c!("reset"),
+            id_chip(&r.session.id),
             score,
             c!("bold"),
-            display_title,
-            c!("reset"),
-            c!("dim"),
-            sid_short,
+            title,
             c!("reset")
         );
         let snippet = snippet_around_match(&r.message.content, query, 200);
@@ -329,10 +319,11 @@ pub fn print_index_results_json(results: &[IndexResult], query: &str) {
 
 pub fn print_inspect(info: &InspectInfo) {
     let tag = src_tag(&info.source);
-    let summary = if info.summary.is_empty() {
+    let cleaned = display_title(&info.summary, 120);
+    let summary = if cleaned.is_empty() {
         "(no summary)"
     } else {
-        &info.summary
+        &cleaned
     };
     println!("\n{}", "─".repeat(80));
     println!("  {}  {}{}{}", tag, c!("bold"), summary, c!("reset"));
@@ -432,10 +423,11 @@ pub fn print_inspect(info: &InspectInfo) {
 
 pub fn print_transcript(messages: &[Message], session: &Session, show_tools: bool) {
     let tag = src_tag(&session.source);
-    let summary = if session.summary.is_empty() {
+    let cleaned = title_of(&session.summary, &session.first_prompt, 120);
+    let summary = if cleaned == "(untitled)" {
         "(no summary)"
     } else {
-        &session.summary
+        &cleaned
     };
     println!("\n{}", "─".repeat(80));
     println!("  {}  {}{}{}", tag, c!("bold"), summary, c!("reset"));

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -171,7 +171,16 @@ pub fn inspect_session(session: &Session) -> Option<InspectInfo> {
     let effective_summary = meta
         .custom_title
         .or(meta.summary)
-        .unwrap_or_else(|| session.summary.clone());
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| {
+            if !session.summary.is_empty() {
+                session.summary.clone()
+            } else {
+                // Same fallback the list rows use, so a session titled by its
+                // first prompt doesn't inspect as "(no summary)".
+                crate::parser::display_title(&session.first_prompt, 120)
+            }
+        });
 
     accomplishments.truncate(10);
     decisions.truncate(5);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use chat_history::dates::parse_human_date;
 use chat_history::session::{
-    self, filter_sessions, find_session, load_all_sessions, parse_session,
+    self, SessionLookup, filter_sessions, load_all_sessions, lookup_session, parse_session,
 };
 use chat_history::skill_install::{ensure_skills, install_skill};
 use chat_history::{display, inspect, scoring, search};
@@ -106,6 +106,29 @@ enum Commands {
         #[arg(long)]
         force: bool,
     },
+}
+
+/// Resolve a session id or prefix, or exit: candidates are listed on an
+/// ambiguous prefix so a short id never silently picks the wrong session.
+fn resolve_session_or_exit<'a>(
+    sessions: &'a [session::Session],
+    sid: &str,
+) -> &'a session::Session {
+    match lookup_session(sessions, sid) {
+        SessionLookup::Found(s) => s,
+        SessionLookup::Ambiguous(candidates) => {
+            eprintln!("Session ID \"{sid}\" is ambiguous — it matches:");
+            for s in &candidates {
+                eprintln!("  {}  {}  {}", s.id, s.date, s.source);
+            }
+            eprintln!("Use a longer prefix.");
+            std::process::exit(2);
+        }
+        SessionLookup::NotFound => {
+            eprintln!("Session not found: {sid}");
+            std::process::exit(1);
+        }
+    }
 }
 
 fn parse_date_arg(val: &Option<String>) -> Option<chrono::NaiveDate> {
@@ -215,15 +238,15 @@ fn main() {
         }
         Some(Commands::Inspect { session_id, last }) => {
             let session = if last {
-                filtered.iter().max_by_key(|s| session::recency_key(s))
+                let Some(s) = filtered.iter().max_by_key(|s| session::recency_key(s)) else {
+                    eprintln!("Session not found");
+                    std::process::exit(1);
+                };
+                s
             } else if let Some(sid) = &session_id {
-                find_session(&sessions, sid)
+                resolve_session_or_exit(&sessions, sid)
             } else {
                 eprintln!("Provide a session ID or use --last");
-                std::process::exit(1);
-            };
-            let Some(session) = session else {
-                eprintln!("Session not found");
                 std::process::exit(1);
             };
             match inspect::inspect_session(session) {
@@ -238,15 +261,15 @@ fn main() {
             plain,
         }) => {
             let session = if last {
-                filtered.iter().max_by_key(|s| session::recency_key(s))
+                let Some(s) = filtered.iter().max_by_key(|s| session::recency_key(s)) else {
+                    eprintln!("Session not found");
+                    std::process::exit(1);
+                };
+                s
             } else if let Some(sid) = &session_id {
-                find_session(&sessions, sid)
+                resolve_session_or_exit(&sessions, sid)
             } else {
                 eprintln!("Provide a session ID or use --last");
-                std::process::exit(1);
-            };
-            let Some(session) = session else {
-                eprintln!("Session not found");
                 std::process::exit(1);
             };
             let (messages, _) = parse_session(session, false);
@@ -257,20 +280,14 @@ fn main() {
             }
         }
         Some(Commands::Export { session_id, output }) => {
-            let Some(session) = find_session(&sessions, &session_id) else {
-                eprintln!("Session not found: {session_id}");
-                std::process::exit(1);
-            };
+            let session = resolve_session_or_exit(&sessions, &session_id);
             let (messages, _) = parse_session(session, false);
             if !display::export_transcript(&messages, session, output.as_deref()) {
                 std::process::exit(1);
             }
         }
         Some(Commands::Resume { session_id }) => {
-            let Some(session) = find_session(&sessions, &session_id) else {
-                eprintln!("Session not found: {session_id}");
-                std::process::exit(1);
-            };
+            let session = resolve_session_or_exit(&sessions, &session_id);
             if session.source != "claude" && session.source != "codex" {
                 eprintln!("Resume is only supported for Claude Code and Codex sessions.");
                 std::process::exit(1);
@@ -321,10 +338,7 @@ fn main() {
             std::process::exit(1);
         }
         Some(Commands::Find { session_id }) => {
-            let Some(session) = find_session(&sessions, &session_id) else {
-                eprintln!("Session not found: {session_id}");
-                std::process::exit(1);
-            };
+            let session = resolve_session_or_exit(&sessions, &session_id);
             println!("{}", session.file);
         }
         Some(Commands::InstallSkill { .. }) => unreachable!(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,7 @@ struct Cli {
     #[arg(
         short = 'L',
         long = "local",
+        global = true,
         help = "Only show sessions from current workspace"
     )]
     local: bool,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -19,6 +19,8 @@ static STRIP_TAGS: &[&str] = &[
     "external_links",
     "rules",
     "agent_skills",
+    "manually_attached_skills",
+    "recommended_plugins",
 ];
 
 static STRIP_TAG_REGEXES: LazyLock<Vec<Regex>> = LazyLock::new(|| {
@@ -190,6 +192,37 @@ pub fn clean_prompt(text: &str) -> String {
     }
     result = CLEAN_MULTI_NL_RE.replace_all(&result, "\n\n").to_string();
     result.trim().to_string()
+}
+
+// Preamble tags stripped from titles even when unclosed (truncated prompts
+// often cut off before the closing tag). `user_query` is excluded — its body
+// IS the title.
+static TITLE_PREAMBLE_RES: LazyLock<Vec<Regex>> = LazyLock::new(|| {
+    STRIP_TAGS
+        .iter()
+        .chain(std::iter::once(&"timestamp"))
+        .map(|tag| Regex::new(&format!(r"(?s)<{tag}>.*?(</{tag}>|\z)")).unwrap())
+        .collect()
+});
+static TITLE_LEFTOVER_TAG_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"</?[a-zA-Z][a-zA-Z0-9_-]{0,60}>").unwrap());
+static TITLE_WS_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\s+").unwrap());
+
+/// One-line title for list/search rows: strips prompt preamble (even when a
+/// closing tag is missing), collapses all whitespace, truncates with an
+/// ellipsis on a char boundary. Returns "" when nothing human-readable is left.
+pub fn display_title(text: &str, max: usize) -> String {
+    let mut t = clean_prompt(text);
+    for re in TITLE_PREAMBLE_RES.iter() {
+        t = re.replace_all(&t, " ").to_string();
+    }
+    let t = TITLE_LEFTOVER_TAG_RE.replace_all(&t, " ");
+    let t = TITLE_WS_RE.replace_all(t.trim(), " ").to_string();
+    let mut out: String = t.chars().take(max).collect();
+    if t.chars().count() > max {
+        out.push('…');
+    }
+    out
 }
 
 pub fn is_noise(text: &str) -> bool {
@@ -583,5 +616,41 @@ mod tests {
         let long = "a".repeat(1000);
         let result = truncate_for_search(&long, 100);
         assert!(result.len() <= 200); // head + tail with space
+    }
+
+    #[test]
+    fn display_title_strips_unclosed_preamble_tag() {
+        let raw =
+            "<manually_attached_skills>\nThe user has manually attached the following skills t";
+        assert_eq!(display_title(raw, 80), "");
+    }
+
+    #[test]
+    fn display_title_keeps_text_after_closed_preamble() {
+        let raw =
+            "<manually_attached_skills>skill stuff</manually_attached_skills>\nfix the login bug";
+        assert_eq!(display_title(raw, 80), "fix the login bug");
+    }
+
+    #[test]
+    fn display_title_collapses_newlines_to_one_line() {
+        let raw = "fix the\n\nlogin   bug\ttoday";
+        assert_eq!(display_title(raw, 80), "fix the login bug today");
+    }
+
+    #[test]
+    fn display_title_truncates_with_ellipsis() {
+        let raw = "a".repeat(100);
+        let out = display_title(&raw, 10);
+        assert_eq!(out.chars().count(), 11);
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn display_title_strips_stray_tags_and_keeps_user_query_body() {
+        let raw = "<user_query>how do I deploy this?</user_query>";
+        assert_eq!(display_title(raw, 80), "how do I deploy this?");
+        let raw2 = "<timestamp>2026-07-22T10:00:00Z</timestamp>ship the release";
+        assert_eq!(display_title(raw2, 80), "ship the release");
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -204,18 +204,28 @@ static TITLE_PREAMBLE_RES: LazyLock<Vec<Regex>> = LazyLock::new(|| {
         .map(|tag| Regex::new(&format!(r"(?s)<{tag}>.*?(</{tag}>|\z)")).unwrap())
         .collect()
 });
+// Lowercase snake/kebab tags of ≥3 chars: catches machine preamble markup
+// while leaving code-like tokens (`Vec<String>`, `<T>`) in titles.
 static TITLE_LEFTOVER_TAG_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"</?[a-zA-Z][a-zA-Z0-9_-]{0,60}>").unwrap());
+    LazyLock::new(|| Regex::new(r"</?[a-z][a-z0-9_-]{2,60}>").unwrap());
 static TITLE_WS_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\s+").unwrap());
 
-/// One-line title for list/search rows: strips prompt preamble (even when a
-/// closing tag is missing), collapses all whitespace, truncates with an
-/// ellipsis on a char boundary. Returns "" when nothing human-readable is left.
-pub fn display_title(text: &str, max: usize) -> String {
+/// Content-level cleaning for stored first prompts: strips preamble (even
+/// when a closing tag is missing) and collapses whitespace, but keeps
+/// code-like tokens and adds no display artifacts.
+pub fn clean_first_prompt(text: &str) -> String {
     let mut t = clean_prompt(text);
     for re in TITLE_PREAMBLE_RES.iter() {
         t = re.replace_all(&t, " ").to_string();
     }
+    TITLE_WS_RE.replace_all(t.trim(), " ").to_string()
+}
+
+/// One-line title for list/search rows: [`clean_first_prompt`] plus stray-tag
+/// removal and ellipsis truncation on a char boundary. Returns "" when
+/// nothing human-readable is left.
+pub fn display_title(text: &str, max: usize) -> String {
+    let t = clean_first_prompt(text);
     let t = TITLE_LEFTOVER_TAG_RE.replace_all(&t, " ");
     let t = TITLE_WS_RE.replace_all(t.trim(), " ").to_string();
     let mut out: String = t.chars().take(max).collect();
@@ -644,6 +654,26 @@ mod tests {
         let out = display_title(&raw, 10);
         assert_eq!(out.chars().count(), 11);
         assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn display_title_keeps_code_like_tokens() {
+        assert_eq!(
+            display_title("implement Vec<String> parsing for <T>", 80),
+            "implement Vec<String> parsing for <T>"
+        );
+    }
+
+    #[test]
+    fn clean_first_prompt_no_ellipsis_and_keeps_code_tokens() {
+        let raw = format!(
+            "<manually_attached_skills>\nstuff\n</manually_attached_skills>\nfix Vec<String> bug {}",
+            "y".repeat(400)
+        );
+        let out = clean_first_prompt(&raw);
+        assert!(out.starts_with("fix Vec<String> bug"));
+        assert!(!out.contains('…'));
+        assert!(!out.contains("manually_attached_skills"));
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,5 +1,5 @@
 use crate::parser::{
-    clean_prompt, display_title, extract_text, is_clear_metadata, is_warmup_message,
+    clean_first_prompt, clean_prompt, extract_text, is_clear_metadata, is_warmup_message,
 };
 use chrono::{DateTime, FixedOffset, NaiveDate, Utc};
 use serde::Deserialize;
@@ -359,9 +359,9 @@ fn cursor_first_prompt_jsonl(path: &Path) -> String {
         // Clean before truncating: the first user message often opens with
         // kilobytes of preamble tags, and a raw prefix would cut off before
         // the actual query.
-        let cleaned = display_title(&text, 300);
+        let cleaned = clean_first_prompt(&text);
         if !cleaned.is_empty() && !is_warmup_message(&cleaned) && !is_clear_metadata(&cleaned) {
-            return cleaned;
+            return cleaned.chars().take(300).collect();
         }
     }
     String::new()

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,4 +1,6 @@
-use crate::parser::{clean_prompt, extract_text, is_clear_metadata, is_warmup_message};
+use crate::parser::{
+    clean_prompt, display_title, extract_text, is_clear_metadata, is_warmup_message,
+};
 use chrono::{DateTime, FixedOffset, NaiveDate, Utc};
 use serde::Deserialize;
 use serde_json::Value;
@@ -336,16 +338,31 @@ fn cursor_first_prompt_jsonl(path: &Path) -> String {
         Err(_) => return String::new(),
     };
     let reader = BufReader::new(file);
-    if let Some(Ok(line)) = reader.lines().next()
-        && let Ok(entry) = serde_json::from_str::<Value>(&line)
-    {
+    for line in reader.lines() {
+        let Ok(line) = line else { continue };
+        let Ok(entry) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        // Role lives at the top level in Cursor agent transcripts; entries
+        // without one are kept as candidates for older formats.
+        if let Some(role) = entry.get("role").and_then(Value::as_str)
+            && role != "user"
+        {
+            continue;
+        }
         let content = entry
             .get("message")
             .and_then(|m| m.get("content"))
             .cloned()
             .unwrap_or(Value::String(String::new()));
         let text = extract_text(&content);
-        return text.chars().take(300).collect();
+        // Clean before truncating: the first user message often opens with
+        // kilobytes of preamble tags, and a raw prefix would cut off before
+        // the actual query.
+        let cleaned = display_title(&text, 300);
+        if !cleaned.is_empty() && !is_warmup_message(&cleaned) && !is_clear_metadata(&cleaned) {
+            return cleaned;
+        }
     }
     String::new()
 }
@@ -1787,6 +1804,37 @@ mod tests {
     #[test]
     fn parse_codex_jsonl_nonexistent_file() {
         assert!(parse_codex_jsonl("/nonexistent/rollout.jsonl").is_empty());
+    }
+
+    #[test]
+    fn cursor_first_prompt_recovers_query_after_long_preamble() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let filler = "x".repeat(500);
+        let data = format!(
+            concat!(
+                r#"{{"role":"user","message":{{"content":[{{"type":"text","text":"<manually_attached_skills>\n{}\n</manually_attached_skills>\n<timestamp>Tuesday, Jul 21, 2026</timestamp>\n<user_query>\nreview security compliance\n</user_query>"}}]}}}}"#,
+                "\n",
+                r#"{{"role":"assistant","message":{{"content":[{{"type":"text","text":"On it."}}]}}}}"#
+            ),
+            filler
+        );
+        std::fs::write(tmp.path(), data).unwrap();
+        assert_eq!(
+            cursor_first_prompt_jsonl(tmp.path()),
+            "review security compliance"
+        );
+    }
+
+    #[test]
+    fn cursor_first_prompt_skips_assistant_lines() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let data = concat!(
+            r#"{"role":"assistant","message":{"content":[{"type":"text","text":"Thinking about the plan."}]}}"#,
+            "\n",
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"fix the login bug"}]}}"#
+        );
+        std::fs::write(tmp.path(), data).unwrap();
+        assert_eq!(cursor_first_prompt_jsonl(tmp.path()), "fix the login bug");
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -1332,16 +1332,38 @@ pub fn recency_key(s: &Session) -> (Option<DateTime<FixedOffset>>, String) {
     (parse_any_timestamp(ts), ts.clone())
 }
 
-pub fn find_session<'a>(sessions: &'a [Session], sid: &str) -> Option<&'a Session> {
-    sessions
+pub enum SessionLookup<'a> {
+    Found(&'a Session),
+    /// Multiple sessions share the prefix — never silently pick one.
+    Ambiguous(Vec<&'a Session>),
+    NotFound,
+}
+
+pub fn lookup_session<'a>(sessions: &'a [Session], sid: &str) -> SessionLookup<'a> {
+    if let Some(s) = sessions.iter().find(|s| s.id.eq_ignore_ascii_case(sid)) {
+        return SessionLookup::Found(s);
+    }
+    let matches: Vec<&Session> = sessions
         .iter()
-        .find(|s| s.id.eq_ignore_ascii_case(sid))
-        .or_else(|| {
-            sessions.iter().find(|s| {
-                s.id.get(..sid.len())
-                    .is_some_and(|prefix| prefix.eq_ignore_ascii_case(sid))
-            })
+        .filter(|s| {
+            s.id.get(..sid.len())
+                .is_some_and(|prefix| prefix.eq_ignore_ascii_case(sid))
         })
+        .collect();
+    match matches.len() {
+        0 => SessionLookup::NotFound,
+        1 => SessionLookup::Found(matches[0]),
+        _ => SessionLookup::Ambiguous(matches),
+    }
+}
+
+/// Exact id or *unique* prefix. Ambiguous prefixes resolve to None; callers
+/// that can report candidates should use [`lookup_session`] instead.
+pub fn find_session<'a>(sessions: &'a [Session], sid: &str) -> Option<&'a Session> {
+    match lookup_session(sessions, sid) {
+        SessionLookup::Found(s) => Some(s),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -1403,6 +1425,25 @@ mod tests {
         assert_eq!(encode_path_for_claude(path), "-Users-x-caf-");
         let cjk = std::path::Path::new("/Users/x/研究");
         assert_eq!(encode_path_for_claude(cjk), "-Users-x---");
+    }
+
+    #[test]
+    fn lookup_session_reports_ambiguous_prefix() {
+        let sessions = vec![
+            make_session("abc-123", "2025-01-01", "claude", "/proj", "main", "one"),
+            make_session("abc-456", "2025-01-02", "cursor", "/proj", "main", "two"),
+        ];
+        match lookup_session(&sessions, "abc") {
+            SessionLookup::Ambiguous(candidates) => assert_eq!(candidates.len(), 2),
+            _ => panic!("expected ambiguous lookup"),
+        }
+        // find_session must not silently pick one of them.
+        assert!(find_session(&sessions, "abc").is_none());
+        // A unique longer prefix still resolves.
+        assert!(matches!(
+            lookup_session(&sessions, "abc-1"),
+            SessionLookup::Found(s) if s.id == "abc-123"
+        ));
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -111,7 +111,11 @@ fn cursor_projects_dir() -> PathBuf {
 }
 
 pub fn codex_home() -> PathBuf {
-    if let Some(dir) = std::env::var_os("CODEX_HOME") {
+    // A set-but-empty CODEX_HOME conventionally means unset; honoring it
+    // would resolve everything relative to the current directory.
+    if let Some(dir) = std::env::var_os("CODEX_HOME")
+        && !dir.is_empty()
+    {
         return PathBuf::from(dir);
     }
     home_dir().join(".codex")

--- a/src/skill_install.rs
+++ b/src/skill_install.rs
@@ -40,7 +40,7 @@ pub fn skill_targets() -> Vec<(PathBuf, &'static str)> {
         targets.push((home.join(".claude/skills/chat-history"), "Claude Code"));
     }
     // Codex: CODEX_HOME, or home-derived ~/.codex when home is known.
-    if std::env::var_os("CODEX_HOME").is_some() || home.is_some() {
+    if std::env::var_os("CODEX_HOME").is_some_and(|v| !v.is_empty()) || home.is_some() {
         targets.push((session::codex_home().join("skills/chat-history"), "Codex"));
     }
     targets

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -315,6 +315,42 @@ fn list_title_is_single_line_without_preamble() {
 }
 
 #[test]
+fn local_flag_is_accepted_after_subcommands() {
+    let tmp = TempDir::new().unwrap();
+    setup_fixture(&tmp);
+    Command::cargo_bin("chat-history")
+        .unwrap()
+        .args(["search", "nomatchquery", "-L"])
+        .env("CLAUDE_CONFIG_DIR", tmp.path())
+        .env("HOME", tmp.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("unexpected argument").not());
+}
+
+#[test]
+fn empty_codex_home_is_treated_as_unset() {
+    let tmp = TempDir::new().unwrap();
+    let cwd = TempDir::new().unwrap();
+    Command::cargo_bin("chat-history")
+        .unwrap()
+        .arg("install-skill")
+        .current_dir(cwd.path())
+        .env("HOME", tmp.path())
+        .env_remove("USERPROFILE")
+        .env("CODEX_HOME", "")
+        .assert()
+        .success();
+    // Falls back to ~/.codex instead of a cwd-relative skills/ directory.
+    assert!(
+        tmp.path()
+            .join(".codex/skills/chat-history/SKILL.md")
+            .exists()
+    );
+    assert!(!cwd.path().join("skills").exists());
+}
+
+#[test]
 fn ambiguous_short_id_lists_candidates_and_fails() {
     let tmp = TempDir::new().unwrap();
     let project_dir = tmp.path().join("projects").join("-Users-test-ambig");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -249,6 +249,71 @@ fn skill_targets_honor_userprofile_without_home() {
     );
 }
 
+#[test]
+fn list_shows_short_ids_by_default() {
+    let tmp = TempDir::new().unwrap();
+    setup_fixture(&tmp);
+    Command::cargo_bin("chat-history")
+        .unwrap()
+        .env("CLAUDE_CONFIG_DIR", tmp.path())
+        .env("HOME", tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("aaaaaaaa"))
+        .stdout(predicate::str::contains("11111111"))
+        .stdout(predicate::str::contains("aaaaaaaa-bbbb").not());
+}
+
+#[test]
+fn summarized_shows_short_ids() {
+    let tmp = TempDir::new().unwrap();
+    setup_fixture(&tmp);
+    Command::cargo_bin("chat-history")
+        .unwrap()
+        .arg("-s")
+        .env("CLAUDE_CONFIG_DIR", tmp.path())
+        .env("HOME", tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("aaaaaaaa"))
+        .stdout(predicate::str::contains("11111111"));
+}
+
+#[test]
+fn list_title_is_single_line_without_preamble() {
+    let tmp = TempDir::new().unwrap();
+    let project_dir = tmp.path().join("projects").join("-Users-test-noisy");
+    fs::create_dir_all(&project_dir).unwrap();
+    let index = serde_json::json!({
+        "entries": [{
+            "sessionId": "99999999-8888-7777-6666-555555555555",
+            "summary": "",
+            "firstPrompt": "<manually_attached_skills>\nThe user has manually attached the following skills to their message.\n</manually_attached_skills>\nfix the flaky\n\ntest suite",
+            "created": "2025-04-01T10:00:00Z",
+            "modified": "2025-04-01T11:00:00Z",
+            "messageCount": 2,
+            "gitBranch": "",
+            "projectPath": "/Users/test/noisy",
+            "fullPath": "",
+            "isSidechain": false
+        }]
+    });
+    fs::write(
+        project_dir.join("sessions-index.json"),
+        serde_json::to_string(&index).unwrap(),
+    )
+    .unwrap();
+
+    Command::cargo_bin("chat-history")
+        .unwrap()
+        .env("CLAUDE_CONFIG_DIR", tmp.path())
+        .env("HOME", tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("fix the flaky test suite"))
+        .stdout(predicate::str::contains("manually_attached_skills").not());
+}
+
 fn setup_fixture(tmp: &TempDir) {
     let project_dir = tmp.path().join("projects").join("-Users-test-project");
     fs::create_dir_all(&project_dir).unwrap();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -314,6 +314,67 @@ fn list_title_is_single_line_without_preamble() {
         .stdout(predicate::str::contains("manually_attached_skills").not());
 }
 
+#[test]
+fn ambiguous_short_id_lists_candidates_and_fails() {
+    let tmp = TempDir::new().unwrap();
+    let project_dir = tmp.path().join("projects").join("-Users-test-ambig");
+    fs::create_dir_all(&project_dir).unwrap();
+    let index = serde_json::json!({
+        "entries": [{
+            "sessionId": "abcd1234-0000-0000-0000-000000000001",
+            "summary": "first candidate",
+            "firstPrompt": "one",
+            "created": "2025-05-01T10:00:00Z",
+            "modified": "2025-05-01T11:00:00Z",
+            "messageCount": 2,
+            "gitBranch": "",
+            "projectPath": "/Users/test/ambig",
+            "fullPath": "",
+            "isSidechain": false
+        }, {
+            "sessionId": "abcd1234-0000-0000-0000-000000000002",
+            "summary": "second candidate",
+            "firstPrompt": "two",
+            "created": "2025-05-02T10:00:00Z",
+            "modified": "2025-05-02T11:00:00Z",
+            "messageCount": 2,
+            "gitBranch": "",
+            "projectPath": "/Users/test/ambig",
+            "fullPath": "",
+            "isSidechain": false
+        }]
+    });
+    fs::write(
+        project_dir.join("sessions-index.json"),
+        serde_json::to_string(&index).unwrap(),
+    )
+    .unwrap();
+
+    Command::cargo_bin("chat-history")
+        .unwrap()
+        .args(["find", "abcd1234"])
+        .env("CLAUDE_CONFIG_DIR", tmp.path())
+        .env("HOME", tmp.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("ambiguous"))
+        .stderr(predicate::str::contains(
+            "abcd1234-0000-0000-0000-000000000001",
+        ))
+        .stderr(predicate::str::contains(
+            "abcd1234-0000-0000-0000-000000000002",
+        ));
+
+    // A longer, unique prefix still resolves.
+    Command::cargo_bin("chat-history")
+        .unwrap()
+        .args(["find", "abcd1234-0000-0000-0000-000000000001"])
+        .env("CLAUDE_CONFIG_DIR", tmp.path())
+        .env("HOME", tmp.path())
+        .assert()
+        .success();
+}
+
 fn setup_fixture(tmp: &TempDir) {
     let project_dir = tmp.path().join("projects").join("-Users-test-project");
     fs::create_dir_all(&project_dir).unwrap();


### PR DESCRIPTION
## Summary

**Every row carries its own address.** All four human views — flat list, day-grouped `-s`, index search, deep search — now show a dim 8-char session-id chip in a fixed column after the date. `find_session` already resolves ID prefixes everywhere a session ID is accepted, so any row can be acted on directly: `ch inspect ae33e3fb`, `ch resume 965570ac`. Previously the list needed `-v` and the grouped view had no way to show IDs at all. `-v` still adds full IDs and file paths.

**Titles are guaranteed single-line.** A new `display_title()` sanitizer strips prompt-preamble tags even when the stored prompt is truncated before the closing tag (`manually_attached_skills`, `recommended_plugins`, `timestamp`, plus the existing strip list), removes stray machine markup (lowercase snake/kebab tags only, so code tokens like `Vec<String>` and `<T>` survive), collapses all whitespace, and truncates with an ellipsis.

**Buried Cursor prompts are recovered.** `cursor_first_prompt_jsonl` used to take a raw 300-char prefix of the first transcript line — when a message opened with kilobytes of attached-skills preamble, the user's actual query further in was lost and rows were titled with markup. It now cleans via `clean_first_prompt()` (content-level: preamble stripped, code tokens kept, no ellipsis) before truncating, and iterates past non-user lines. A real session that rendered as two lines of `<manually_attached_skills>` soup now shows its true title (`/review-security HIPPA GDPR …`).

**Output-stability note for agents:** deep-search `--json` and `--plain` are unchanged. Index-search JSON snippets and anything derived from Cursor `first_prompt` get *cleaner* content than before (preamble stripped) — a deliberate data improvement, not a format change. Color already auto-disables for pipes and `NO_COLOR`. `SKILL.md` updated: `-v` is no longer required for IDs, and short IDs are documented as accepted everywhere.

## Before / after

```
before:
    1.  CR  2026-07-21  <manually_attached_skills>
The user has manually attached the following skills t

after:
    1.  CR  2026-07-21  ae33e3fb  /review-security HIPPA GDPR and other healthcare compliance stuff as wel…
```

## Test plan

- [x] `cargo test` — 180 unit + 76 integration (12 new: preamble stripping incl. unclosed tags, whitespace collapse, ellipsis truncation, `user_query` body preserved, code-token preservation, no display artifacts in stored prompts, default short IDs in list and grouped views, single-line titles end-to-end, Cursor prompt recovery after long preamble, assistant-line skipping)
- [x] `cargo fmt --check`, `cargo clippy`
- [x] Release build verified against real history: list/grouped/search alignment, zero markup titles across the full session list, formerly garbled Cursor row shows its real query, piped output free of ANSI codes, `ch find ae33e3fb` short-ID roundtrip
- [x] Rebased onto `main` after #14's squash-merge; no duplicated commits, conflicts resolved