### PR TITLE
CLI polish: help coverage, input validation, shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,7 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "clap",
+ "clap_complete",
  "glob",
  "libc",
  "predicates",
@@ -187,6 +188,15 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+dependencies = [
+ "clap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ path = "src/main.rs"
 [dependencies]
 chrono = { version = "0.4.31", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 glob = "0.3"
 rayon = "1.10"
 regex = "1"

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ chat-history view <id> --tools
 chat-history export <id> -o session.md
 chat-history resume <id>                  # Claude Code or Codex only
 chat-history find <id>                    # absolute path for further tooling
+
+# Shell completions (bash, zsh, fish, elvish, powershell)
+chat-history completions zsh
 ```
 
 `ch` is a drop-in alias: `ch search "auth" --deep --json`.
@@ -87,8 +90,8 @@ chat-history --branch feature-xyz
 chat-history --from "3 days ago" --to today
 chat-history --sidechains                 # include hidden subagent/sidechain sessions
 
-# Apply workspace scope to a search (-L must precede the subcommand)
-chat-history -L search "auth" --deep --json
+# Apply workspace scope to a search (-L works before or after the subcommand)
+chat-history search "auth" --deep --json -L
 
 # Listing-only presentation flags
 chat-history --from yesterday -s          # group by day

--- a/SKILL.md
+++ b/SKILL.md
@@ -39,7 +39,7 @@ Search, inspect, and export Claude Code, Cursor, and Codex conversation history.
 ## Common mistakes
 
 - Only `search` accepts `--json`; the session list and `inspect` reject it.
-- The only subcommands are `search`, `inspect`, `view`, `export`, `resume`, `find`, `install-skill`. Do not guess others; run `chat-history --help` when unsure.
+- The only subcommands are `search`, `inspect`, `view`, `export`, `resume`, `find`, `install-skill`, `completions`. Do not guess others; run `chat-history --help` when unsure.
 - Don't dump raw JSON or full transcripts at the user — summarize, cite the session ID and date.
 - Some Cursor sessions have thin metadata (`(no summary)`, `duration: 0min`, raw first-message titles). If `inspect` is thin, fall back to `chat-history view <id> --plain`.
 
@@ -67,6 +67,7 @@ chat-history view <id> --plain             # transcript, pipe-friendly (--tools 
 chat-history export <id> -o session.md
 chat-history resume <id>                   # resume a Claude Code or Codex session
 chat-history find <id>                     # print transcript file path for scripting
+chat-history completions zsh               # shell completions (bash/zsh/fish/elvish/powershell)
 ```
 
 - `--scope` values: `all` (default), `errors` (messages with error patterns or the word "error"), `similar` (user messages only — similar past queries), `tools` (messages with tool calls), `files` (messages referencing files). Any scope other than `all` always searches full transcripts.

--- a/src/display.rs
+++ b/src/display.rs
@@ -6,7 +6,9 @@ use std::collections::BTreeMap;
 use std::sync::LazyLock;
 
 static USE_COLOR: LazyLock<bool> = LazyLock::new(|| {
-    std::io::IsTerminal::is_terminal(&std::io::stdout()) && std::env::var("NO_COLOR").is_err()
+    std::io::IsTerminal::is_terminal(&std::io::stdout())
+        && std::env::var("NO_COLOR").is_err()
+        && std::env::var("TERM").map(|t| t != "dumb").unwrap_or(true)
 });
 
 macro_rules! c {

--- a/src/main.rs
+++ b/src/main.rs
@@ -200,12 +200,16 @@ fn main() {
 
     if let Some(Commands::Completions { shell }) = &cli.command {
         use clap::CommandFactory;
-        clap_complete::generate(
-            *shell,
-            &mut Cli::command(),
-            "chat-history",
-            &mut std::io::stdout(),
-        );
+        // Use the invoked binary name so the `ch` alias gets working
+        // completions too, not a `_chat-history` function it never triggers.
+        let bin = std::env::args()
+            .next()
+            .as_deref()
+            .map(std::path::Path::new)
+            .and_then(|p| p.file_name())
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "chat-history".to_string());
+        clap_complete::generate(*shell, &mut Cli::command(), bin, &mut std::io::stdout());
         return;
     }
 
@@ -302,7 +306,7 @@ fn main() {
                 resolve_session_or_exit(&sessions, sid)
             } else {
                 eprintln!("Provide a session ID or use --last");
-                std::process::exit(1);
+                std::process::exit(2);
             };
             match inspect::inspect_session(session) {
                 Some(info) => display::print_inspect(&info),
@@ -325,7 +329,7 @@ fn main() {
                 resolve_session_or_exit(&sessions, sid)
             } else {
                 eprintln!("Provide a session ID or use --last");
-                std::process::exit(1);
+                std::process::exit(2);
             };
             let (messages, _) = parse_session(session, false);
             if plain {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,18 @@ use clap::{Parser, Subcommand};
 #[command(
     name = "chat-history",
     about = "Search Claude Code + Cursor + Codex conversation history",
-    version
+    long_about = "Search Claude Code + Cursor + Codex conversation history.\n\n\
+        With no command, lists sessions newest first; every row shows a short\n\
+        session ID usable with inspect/view/export/resume/find.",
+    version,
+    after_help = "EXAMPLES:\n  \
+        chat-history                                  list sessions, newest first\n  \
+        chat-history --from yesterday --to yesterday  sessions from a specific day\n  \
+        chat-history search \"auth error\" --deep --json\n  \
+        chat-history inspect 6b1094cd                 summarize by short ID\n  \
+        chat-history view 6b1094cd --plain | less\n\n\
+        EXIT CODES:\n  \
+        0 success, 1 not found / IO error, 2 usage error or ambiguous session ID"
 )]
 struct Cli {
     #[command(subcommand)]
@@ -26,7 +37,12 @@ struct Cli {
     #[arg(long = "to", global = true, help = "End date")]
     to_date: Option<String>,
 
-    #[arg(long, global = true, help = "Filter by source (claude/cursor/codex)")]
+    #[arg(
+        long,
+        global = true,
+        value_parser = ["claude", "cursor", "codex"],
+        help = "Filter by source"
+    )]
     source: Option<String>,
 
     #[arg(long, global = true, help = "Filter by project path substring")]
@@ -62,42 +78,64 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Search session content and metadata (add --deep --json from agents)
     Search {
+        /// Search query, or a full session UUID for direct lookup
         query: String,
-        #[arg(long, default_value = "all")]
+        /// What to search within transcripts
+        #[arg(long, default_value = "all", value_parser = ["all", "errors", "similar", "tools", "files"])]
         scope: String,
+        /// Search full transcript content instead of the fast index
         #[arg(long)]
         deep: bool,
+        /// Maximum number of results
         #[arg(long, default_value_t = 15)]
         limit: usize,
+        /// Only messages newer than this (e.g. "2 days", "1 week")
         #[arg(long)]
         timeframe: Option<String>,
+        /// Structured JSON output (session_id, score, snippet, tools, files)
         #[arg(long = "json")]
         json_output: bool,
     },
+    /// Summarize a session: accomplishments, tools, files, model, tokens
     Inspect {
+        /// Session ID or unique prefix
         session_id: Option<String>,
+        /// Inspect the most recent session
         #[arg(long)]
         last: bool,
     },
+    /// Print a session transcript
     View {
+        /// Session ID or unique prefix
         session_id: Option<String>,
+        /// View the most recent session
         #[arg(long)]
         last: bool,
+        /// Show tool call names inline
         #[arg(long)]
         tools: bool,
+        /// Plain text without formatting, pipe-friendly
         #[arg(long)]
         plain: bool,
     },
+    /// Export a session transcript as markdown
     Export {
+        /// Session ID or unique prefix
         session_id: String,
+        /// Output file (stdout if omitted)
         #[arg(short = 'o', long)]
         output: Option<String>,
     },
+    /// Resume a Claude Code or Codex session in its original tool
     Resume {
+        /// Session ID or unique prefix
         session_id: String,
     },
+    /// Print the transcript file path for scripting
     Find {
+        /// Session ID or unique prefix
         session_id: String,
     },
     /// Install the agent skill for Claude Code, Cursor, and Codex
@@ -106,6 +144,11 @@ enum Commands {
         /// Overwrite existing skills even if they were user-edited
         #[arg(long)]
         force: bool,
+    },
+    /// Generate shell completions (bash, zsh, fish, elvish, powershell)
+    Completions {
+        /// Shell to generate completions for
+        shell: clap_complete::Shell,
     },
 }
 
@@ -139,7 +182,7 @@ fn parse_date_arg(val: &Option<String>) -> Option<chrono::NaiveDate> {
                 "Invalid date: '{}'. Try: YYYY-MM-DD, today, yesterday, '3 days ago', 'last week'",
                 v
             );
-            std::process::exit(1);
+            std::process::exit(2);
         })
     })
 }
@@ -154,6 +197,17 @@ fn main() {
     }
 
     let cli = Cli::parse();
+
+    if let Some(Commands::Completions { shell }) = &cli.command {
+        use clap::CommandFactory;
+        clap_complete::generate(
+            *shell,
+            &mut Cli::command(),
+            "chat-history",
+            &mut std::io::stdout(),
+        );
+        return;
+    }
 
     if let Some(Commands::InstallSkill { force }) = &cli.command {
         install_skill(*force);
@@ -342,7 +396,7 @@ fn main() {
             let session = resolve_session_or_exit(&sessions, &session_id);
             println!("{}", session.file);
         }
-        Some(Commands::InstallSkill { .. }) => unreachable!(),
+        Some(Commands::InstallSkill { .. }) | Some(Commands::Completions { .. }) => unreachable!(),
         None => {
             if cli.summarize {
                 display::print_summarized(&filtered);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -355,6 +355,33 @@ fn completions_generate_for_bash() {
 }
 
 #[test]
+fn completions_use_invoked_binary_name() {
+    let tmp = TempDir::new().unwrap();
+    Command::cargo_bin("ch")
+        .unwrap()
+        .env("CLAUDE_CONFIG_DIR", tmp.path())
+        .env("HOME", tmp.path())
+        .env_remove("CODEX_HOME")
+        .args(["completions", "bash"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("complete -F _ch "))
+        .stdout(predicate::str::contains("chat-history").not());
+}
+
+#[test]
+fn missing_session_id_is_usage_error() {
+    for subcmd in ["inspect", "view"] {
+        let (mut cmd, _tmp) = isolated_cmd();
+        cmd.arg(subcmd)
+            .assert()
+            .failure()
+            .code(2)
+            .stderr(predicate::str::contains("--last"));
+    }
+}
+
+#[test]
 fn help_shows_examples_and_subcommand_about() {
     Command::cargo_bin("chat-history")
         .unwrap()
@@ -450,6 +477,7 @@ fn ambiguous_short_id_lists_candidates_and_fails() {
         .env("HOME", tmp.path())
         .assert()
         .failure()
+        .code(2)
         .stderr(predicate::str::contains("ambiguous"))
         .stderr(predicate::str::contains(
             "abcd1234-0000-0000-0000-000000000001",

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -315,6 +315,63 @@ fn list_title_is_single_line_without_preamble() {
 }
 
 #[test]
+fn invalid_source_fails_with_usage_error() {
+    let (mut cmd, _tmp) = isolated_cmd();
+    cmd.args(["--source", "nope"])
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(predicate::str::contains("possible values"))
+        .stderr(predicate::str::contains("claude"));
+}
+
+#[test]
+fn invalid_scope_fails_with_usage_error() {
+    let (mut cmd, _tmp) = isolated_cmd();
+    cmd.args(["search", "q", "--scope", "eror"])
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(predicate::str::contains("possible values"));
+}
+
+#[test]
+fn invalid_date_exits_with_usage_code() {
+    let (mut cmd, _tmp) = isolated_cmd();
+    cmd.args(["--from", "notadate"])
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(predicate::str::contains("Invalid date"));
+}
+
+#[test]
+fn completions_generate_for_bash() {
+    let (mut cmd, _tmp) = isolated_cmd();
+    cmd.args(["completions", "bash"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("chat-history"));
+}
+
+#[test]
+fn help_shows_examples_and_subcommand_about() {
+    Command::cargo_bin("chat-history")
+        .unwrap()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("EXAMPLES:"))
+        .stdout(predicate::str::contains("EXIT CODES:"));
+    Command::cargo_bin("chat-history")
+        .unwrap()
+        .args(["search", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("full transcript content"));
+}
+
+#[test]
 fn local_flag_is_accepted_after_subcommands() {
     let tmp = TempDir::new().unwrap();
     setup_fixture(&tmp);


### PR DESCRIPTION
## Summary

- **Help is a real UI surface:** every subcommand has an about line, every flag a help string; top-level `--help` documents the no-command default, examples, and an exit-code table (0 success / 1 not found·IO / 2 usage or ambiguous ID).
- **No more fail-soft on bad input:** `--source` and `--scope` validate via clap (`exit 2` + possible values). Previously `--source nope` looked like empty success, and an unknown `--scope` silently behaved like `all`. Invalid dates and `inspect`/`view` with no ID (and no `--last`) also exit 2.
- **Shell completions:** `chat-history completions <bash|zsh|fish|elvish|powershell>` via `clap_complete`. Side-effect free (runs before session load / skill bootstrap). Uses the invoked binary name so `ch completions zsh` emits `#compdef ch`, not a dead `_chat-history` function.
- **`TERM=dumb` disables color**, completing the clig.dev color checklist alongside TTY + `NO_COLOR`.
- **Docs:** README documents global `-L` and `completions`; SKILL.md lists `completions` in the authoritative subcommand set agents rely on.

Deliberately not included (assessed, deferred): `--json` on list/inspect (own PR), git SHA in `--version`, auto-paging (conflicts with agent-first design), progress indicators (deep search is subsecond on a multi-year corpus).

## Test plan

- [x] `cargo test` — 181 unit + 86 integration
- [x] New coverage: invalid `--source`/`--scope`/date → exit 2; help examples + subcommand about; bash completions; `ch`-named completions; missing `inspect`/`view` ID → exit 2; ambiguous short ID asserts `.code(2)`
- [x] `cargo fmt --check`, `cargo clippy`
- [x] Manual: `--help`; `--source nope`; `inspect` (no args) → exit 2; `completions zsh` / `ch completions zsh` headers