### PR TITLE
Add Cursor IDE history, clearer source tags, and search by sidebar title

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +161,7 @@ dependencies = [
  "predicates",
  "rayon",
  "regex",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",
@@ -283,6 +296,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +355,15 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -342,6 +376,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -426,6 +469,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +523,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "predicates"
@@ -584,6 +644,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +732,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,6 +790,18 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -971,6 +1063,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ rayon = "1.10"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+rusqlite = { version = "0.32", features = ["bundled"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -113,12 +113,12 @@ All JSON output uses a `{ "query", "count", "results" }` envelope. Deep-search r
 
 Scopes: `all` (default), `errors`, `similar`, `tools`, `files`. Use `--timeframe today|week|month|Nd` and `--limit N` (default 15) to constrain results.
 
-Human-readable Claude/Codex/`cursor-agent` results include an 8-char UUID prefix — pass that to `inspect`, `view`, `export`, `resume`, or `find`. Rows tagged `cursor-ide` show `--------` instead; find them in the Cursor sidebar by **title** and `DIR:`. `resume` on those ids prints that hint and does not start the Agent CLI.
+Human-readable results include an 8-char UUID prefix — pass that to `inspect`, `view`, `export`, or `find` for any source, and to `resume` for `claude`, `codex` and `cursor-agent` rows. `resume` on a `cursor-ide` id does not start the Agent CLI; it prints the chat's **title** and `DIR:` so you can open it in the Cursor sidebar.
 
 Example (index search, not `--json`):
 
 ```
-  1.  cursor-ide    2026-07-30 -------- ★ 7.5 DIR: ~/proj INDEX_FIELD: summary
+  1.  cursor-ide    2026-07-30 3f9c1a2e ★ 7.5 DIR: ~/proj INDEX_FIELD: summary
         Restore optimization
   2.  cursor-agent  2026-08-20 2f5bb25d ★ 4.0 DIR: ~/tmp INDEX_FIELD: first_prompt
         Please read over the setup guide…
@@ -130,7 +130,7 @@ Example (index search, not `--json`):
 
 - Display tags: `claude` = Claude Code, `cursor-ide` = Cursor IDE sidebar, `cursor-agent` = Agent CLI / jsonl-only, `codex` = Codex
 - Cursor IDE **Agent mode** writes SQLite **and** a jsonl with the same composer id. Search lists that pair **once** as `cursor-ide`. `--source cursor` / `cursor-agent` is the jsonl store; `--source cursor-ide` is SQLite.
-- Header line: source, date, short id (or `--------` for `cursor-ide`), score, `DIR:` spawn directory (`$HOME` shown as `~`), and (index search) `INDEX_FIELD:`
+- Header line: source, date, short id, score, `DIR:` spawn directory (`$HOME` shown as `~`), and (index search) `INDEX_FIELD:`
 - Title / match text is on the following indented line
 - `★ N.N` = relevance (higher is better)
 - `INDEX_FIELD:` is `summary`, `first_prompt`, or `branch`

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Date formats: `YYYY-MM-DD`, `today`, `yesterday`, `"3 days ago"`, `"last week"`,
 | `--json` | Machine-readable search output. This flag is available on `search`, not `inspect` or `view`. |
 | (default index) | Fast metadata-only search (title/summary, first prompt, branch, project). Weak results (★ < 5.0) fall through to deep search, except curated summary/title hits at ★ 4.5+. |
 
-All JSON output uses a `{ "query", "count", "results" }` envelope. Deep-search result items include `session_id`, `source`, `date`, `summary`, `project`, `score`, `role`, `snippet`, `tools`, and `files`. Index result items include `matched_field` instead of `role`, `tools`, and `files`, and the envelope includes `"search_type": "index"`.
+All JSON output uses a `{ "query", "count", "results" }` envelope. Deep-search result items include `session_id`, `source`, `also_ide`, `date`, `summary`, `project`, `score`, `role`, `snippet`, `tools`, and `files`. Index result items include `matched_field` instead of `role`, `tools`, and `files`, and the envelope includes `"search_type": "index"`.
 
 Scopes: `all` (default), `errors`, `similar`, `tools`, `files`. Use `--timeframe today|week|month|Nd` and `--limit N` (default 15) to constrain results.
 
@@ -124,7 +124,7 @@ Example (index search, not `--json`):
         Please read over the setup guide…
 ```
 
-`--json` still includes `session_id`. For IDE Agent chats the JSON `source` is `cursor` (the jsonl store) even though the human tag is `cursor-ide`; `resume` still refuses those.
+`--json` still includes `session_id`. For IDE Agent chats the JSON `source` is `cursor` (the jsonl store) even though the human tag is `cursor-ide`; those items carry `"also_ide": true`, and `resume` refuses them.
 
 ### Interpreting output
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ These filters apply to session listing, `search`, and `--last` selection. Explic
 
 ```bash
 # Listing / search / --last filters
-chat-history --source claude              # claude | cursor | cursor-agent | codex
+chat-history --source claude              # claude | cursor | cursor-agent | cursor-ide | codex
 chat-history --project chat-history
 chat-history --branch feature-xyz
 chat-history --from "3 days ago" --to today
@@ -106,7 +106,7 @@ Date formats: `YYYY-MM-DD`, `today`, `yesterday`, `"3 days ago"`, `"last week"`,
 |---|---|
 | `--deep` | Force full transcript search for the default `all` scope. Specialized scopes already scan transcript content. Snippets are match-centered, not message prefixes. |
 | `--json` | Machine-readable search output. This flag is available on `search`, not `inspect` or `view`. |
-| (default index) | Fast metadata-only search (title/summary, first prompt, branch, project). Weak results (★ < 5.0) fall through to deep search automatically. |
+| (default index) | Fast metadata-only search (title/summary, first prompt, branch, project). Weak results (★ < 5.0) fall through to deep search, except curated summary/title hits at ★ 4.5+. |
 
 All JSON output uses a `{ "query", "count", "results" }` envelope. Deep-search result items include `session_id`, `source`, `date`, `summary`, `project`, `score`, `role`, `snippet`, `tools`, and `files`. Index result items include `matched_field` instead of `role`, `tools`, and `files`, and the envelope includes `"search_type": "index"`.
 
@@ -116,7 +116,7 @@ Human-readable results include an 8-char UUID prefix (e.g. `[e363d98d]`) — pas
 
 ### Interpreting output
 
-- `claude` = Claude Code, `agent` = Cursor Agent, `codex` = Codex
+- `claude` = Claude Code, `cursor` = Cursor Agent transcripts, `cursor-ide` = Cursor IDE SQLite, `codex` = Codex (`cursor-agent` is an alias for `cursor`)
 - Header line: source, date, short id, score, `DIR:` spawn directory (`$HOME` shown as `~`), and (index search) `INDEX_FIELD:`
 - Title / match text is on the following indented line
 - `★ N.N` = relevance (higher is better)
@@ -131,7 +131,8 @@ Human-readable results include an 8-char UUID prefix (e.g. `[e363d98d]`) — pas
 | Source | Path |
 |---|---|
 | Claude Code | `~/.claude/projects/*/*.jsonl` (+ optional legacy `sessions-index.json`) |
-| Cursor | `~/.cursor/projects/*/agent-transcripts/` |
+| Cursor Agent | `~/.cursor/projects/*/agent-transcripts/` (`--source cursor`, alias `cursor-agent`) |
+| Cursor IDE | `.../Cursor/User/globalStorage/state.vscdb` (override with `CURSOR_USER_DIR`; `--source cursor-ide`) |
 | Cursor subagents | `.../agent-transcripts/*/subagents/*.jsonl` |
 | Codex | `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-*.jsonl` (default `~/.codex`) |
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ chat-history inspect <partial-uuid>
 chat-history view --last --plain
 chat-history view <id> --tools
 chat-history export <id> -o session.md
-chat-history resume <id>                  # Claude Code or Codex only
+chat-history resume <id>                  # Claude Code, Cursor Agent, or Codex
 chat-history find <id>                    # absolute path for further tooling
 
 # Shell completions (bash, zsh, fish, elvish, powershell)
@@ -84,7 +84,7 @@ These filters apply to session listing, `search`, and `--last` selection. Explic
 
 ```bash
 # Listing / search / --last filters
-chat-history --source claude              # claude | cursor | codex
+chat-history --source claude              # claude | cursor | cursor-agent | codex
 chat-history --project chat-history
 chat-history --branch feature-xyz
 chat-history --from "3 days ago" --to today
@@ -116,9 +116,11 @@ Human-readable results include an 8-char UUID prefix (e.g. `[e363d98d]`) — pas
 
 ### Interpreting output
 
-- `CC` = Claude Code, `CR` = Cursor, `CX` = Codex
+- `claude` = Claude Code, `agent` = Cursor Agent, `codex` = Codex
+- Header line: source, date, short id, score, `DIR:` spawn directory (`$HOME` shown as `~`), and (index search) `INDEX_FIELD:`
+- Title / match text is on the following indented line
 - `★ N.N` = relevance (higher is better)
-- `[summary]` / `[first_prompt]` / `[branch]` = which index field matched
+- `INDEX_FIELD:` is `summary`, `first_prompt`, or `branch`
 - `inspect` → duration, messages, model, tokens, tools, files, accomplishments, key decisions
 - Claude Code titles come from `ai-title` / `custom-title` JSONL when available
 - Subagent/sidechain sessions are omitted unless `--sidechains`; this includes Cursor transcripts under `agent-transcripts/*/subagents/` (tagged `[subagent]`)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ chat-history inspect <partial-uuid>
 chat-history view --last --plain
 chat-history view <id> --tools
 chat-history export <id> -o session.md
-chat-history resume <id>                  # Claude / Agent CLI / Codex — not cursor-ide
+chat-history resume <id>                  # Claude / Codex / Cursor Agent CLI chats — IDE chats print a hint
 chat-history find <id>                    # absolute path for further tooling
 
 # Shell completions (bash, zsh, fish, elvish, powershell)
@@ -113,7 +113,7 @@ All JSON output uses a `{ "query", "count", "results" }` envelope. Deep-search r
 
 Scopes: `all` (default), `errors`, `similar`, `tools`, `files`. Use `--timeframe today|week|month|Nd` and `--limit N` (default 15) to constrain results.
 
-Human-readable results include an 8-char UUID prefix — pass that to `inspect`, `view`, `export`, or `find` for any source, and to `resume` for `claude`, `codex` and `cursor-agent` rows. `resume` on a `cursor-ide` id does not start the Agent CLI; it prints the chat's **title** and `DIR:` so you can open it in the Cursor sidebar.
+Human-readable results include an 8-char UUID prefix — pass that to `inspect`, `view`, `export`, or `find` for any source, and to `resume` for `claude`, `codex` and Cursor Agent CLI chats (ids that have a store under `~/.cursor/chats`; the CLI is launched in that chat's own workspace). Any other Cursor row — `cursor-ide`, or an Agent transcript whose CLI store is gone — prints the chat's **title** and `DIR:` so you can open it in the Cursor sidebar: the Agent CLI cannot load IDE chats and would start a blank chat that reuses the id.
 
 Example (index search, not `--json`):
 

--- a/README.md
+++ b/README.md
@@ -112,12 +112,12 @@ All JSON output uses a `{ "query", "count", "results" }` envelope. Deep-search r
 
 Scopes: `all` (default), `errors`, `similar`, `tools`, `files`. Use `--timeframe today|week|month|Nd` and `--limit N` (default 15) to constrain results.
 
-Human-readable results include an 8-char UUID prefix (e.g. `[e363d98d]`) — pass that to `inspect`, `view`, `export`, `resume`, or `find`.
+Human-readable Claude/Codex/`cursor-agent` results include an 8-char UUID prefix — pass that to `inspect`, `view`, `export`, `resume`, or `find`. Rows tagged `cursor-ide` omit that prefix and cannot be resumed from the CLI.
 
 ### Interpreting output
 
-- `claude` = Claude Code, `cursor` = Cursor Agent transcripts, `cursor-ide` = Cursor IDE SQLite, `codex` = Codex (`cursor-agent` is an alias for `cursor`)
-- Header line: source, date, short id, score, `DIR:` spawn directory (`$HOME` shown as `~`), and (index search) `INDEX_FIELD:`
+- Display tags: `claude` = Claude Code, `cursor-ide` = Cursor IDE sidebar (Agent-mode chats in the IDE are still `cursor-ide`; they also have a jsonl on disk), `cursor-agent` = Agent CLI / jsonl-only, `codex` = Codex (`--source cursor-agent` still means jsonl transcripts)
+- Header line: source, date, short id (or `--------` for IDE-only composers), score, `DIR:` spawn directory (`$HOME` shown as `~`), and (index search) `INDEX_FIELD:`
 - Title / match text is on the following indented line
 - `★ N.N` = relevance (higher is better)
 - `INDEX_FIELD:` is `summary`, `first_prompt`, or `branch`

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ chat-history inspect <partial-uuid>
 chat-history view --last --plain
 chat-history view <id> --tools
 chat-history export <id> -o session.md
-chat-history resume <id>                  # Claude Code, Cursor Agent, or Codex
+chat-history resume <id>                  # Claude / Agent CLI / Codex — not cursor-ide
 chat-history find <id>                    # absolute path for further tooling
 
 # Shell completions (bash, zsh, fish, elvish, powershell)
@@ -85,6 +85,7 @@ These filters apply to session listing, `search`, and `--last` selection. Explic
 ```bash
 # Listing / search / --last filters
 chat-history --source claude              # claude | cursor | cursor-agent | cursor-ide | codex
+                                          # cursor = cursor-agent = jsonl; cursor-ide = sidebar
 chat-history --project chat-history
 chat-history --branch feature-xyz
 chat-history --from "3 days ago" --to today
@@ -112,12 +113,24 @@ All JSON output uses a `{ "query", "count", "results" }` envelope. Deep-search r
 
 Scopes: `all` (default), `errors`, `similar`, `tools`, `files`. Use `--timeframe today|week|month|Nd` and `--limit N` (default 15) to constrain results.
 
-Human-readable Claude/Codex/`cursor-agent` results include an 8-char UUID prefix — pass that to `inspect`, `view`, `export`, `resume`, or `find`. Rows tagged `cursor-ide` omit that prefix and cannot be resumed from the CLI.
+Human-readable Claude/Codex/`cursor-agent` results include an 8-char UUID prefix — pass that to `inspect`, `view`, `export`, `resume`, or `find`. Rows tagged `cursor-ide` show `--------` instead; find them in the Cursor sidebar by **title** and `DIR:`. `resume` on those ids prints that hint and does not start the Agent CLI.
+
+Example (index search, not `--json`):
+
+```
+  1.  cursor-ide    2026-07-30 -------- ★ 7.5 DIR: ~/proj INDEX_FIELD: summary
+        Restore optimization
+  2.  cursor-agent  2026-08-20 2f5bb25d ★ 4.0 DIR: ~/tmp INDEX_FIELD: first_prompt
+        Please read over the setup guide…
+```
+
+`--json` still includes `session_id`. For IDE Agent chats the JSON `source` is `cursor` (the jsonl store) even though the human tag is `cursor-ide`; `resume` still refuses those.
 
 ### Interpreting output
 
-- Display tags: `claude` = Claude Code, `cursor-ide` = Cursor IDE sidebar (Agent-mode chats in the IDE are still `cursor-ide`; they also have a jsonl on disk), `cursor-agent` = Agent CLI / jsonl-only, `codex` = Codex (`--source cursor-agent` still means jsonl transcripts)
-- Header line: source, date, short id (or `--------` for IDE-only composers), score, `DIR:` spawn directory (`$HOME` shown as `~`), and (index search) `INDEX_FIELD:`
+- Display tags: `claude` = Claude Code, `cursor-ide` = Cursor IDE sidebar, `cursor-agent` = Agent CLI / jsonl-only, `codex` = Codex
+- Cursor IDE **Agent mode** writes SQLite **and** a jsonl with the same composer id. Search lists that pair **once** as `cursor-ide`. `--source cursor` / `cursor-agent` is the jsonl store; `--source cursor-ide` is SQLite.
+- Header line: source, date, short id (or `--------` for `cursor-ide`), score, `DIR:` spawn directory (`$HOME` shown as `~`), and (index search) `INDEX_FIELD:`
 - Title / match text is on the following indented line
 - `★ N.N` = relevance (higher is better)
 - `INDEX_FIELD:` is `summary`, `first_prompt`, or `branch`
@@ -132,7 +145,7 @@ Human-readable Claude/Codex/`cursor-agent` results include an 8-char UUID prefix
 |---|---|
 | Claude Code | `~/.claude/projects/*/*.jsonl` (+ optional legacy `sessions-index.json`) |
 | Cursor Agent | `~/.cursor/projects/*/agent-transcripts/` (`--source cursor`, alias `cursor-agent`) |
-| Cursor IDE | `.../Cursor/User/globalStorage/state.vscdb` (override with `CURSOR_USER_DIR`; `--source cursor-ide`) |
+| Cursor IDE | `.../Cursor/User/globalStorage/state.vscdb` (override with `CURSOR_USER_DIR`; `--source cursor-ide`). IDE Agent chats also get a jsonl in the Agent path above; they still list as `cursor-ide`. |
 | Cursor subagents | `.../agent-transcripts/*/subagents/*.jsonl` |
 | Codex | `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-*.jsonl` (default `~/.codex`) |
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -75,7 +75,7 @@ chat-history completions zsh               # shell completions (bash/zsh/fish/el
 
 ## Interpreting output
 
-- `claude` = Claude Code, `cursor` = Cursor Agent transcripts, `cursor-ide` = Cursor IDE SQLite, `codex` = Codex; `★ N.N` = relevance score. `--source cursor-agent` is an alias for `cursor`.
-- Header line has `DIR:` (spawn directory) and, for index search, `INDEX_FIELD:` (`summary` / `first_prompt` / `branch`). Title is on the next line. Every displayed short ID can be passed to `inspect` / `view` / `export` / `find`. `resume` on `cursor-ide` rows prints how to open the chat in the Cursor UI.
+- Display tags: `claude` = Claude Code, `cursor-ide` = Cursor IDE sidebar (SQLite; IDE Agent chats also write a jsonl under `agent-transcripts/` with the same id), `cursor-agent` = Cursor Agent CLI / transcript-only jsonl, `codex` = Codex; `★ N.N` = relevance score.
+- Header line has `DIR:` (spawn directory) and, for index search, `INDEX_FIELD:` (`summary` / `first_prompt` / `branch`). Title is on the next line. Claude/Codex/`cursor-agent` short IDs can be passed to `inspect` / `view` / `export` / `find` / `resume`. Rows tagged `cursor-ide` hide the composer UUID and **cannot** be `resume`d from the CLI (prints how to find the chat in the Cursor sidebar), even when an `agent-transcripts` jsonl exists for the same id. `list -v` / JSON still have the id for `inspect` / `view` / `find`.
 - `COPIES: N` means the same Cursor Agent session id exists in more than one project folder; `inspect`/`resume`/`find` pick one copy (cwd match, else newest) and print the others.
 - Accepted dates: `YYYY-MM-DD`, `today`, `yesterday`, `"3 days ago"`, `"last week"`, `"last month"`.

--- a/SKILL.md
+++ b/SKILL.md
@@ -50,7 +50,7 @@ Search, inspect, and export Claude Code, Cursor, and Codex conversation history.
 chat-history                                      # newest first; short IDs on every row (-v for full IDs + paths)
 chat-history --from yesterday --to yesterday -s   # a specific day, grouped
 chat-history --from "3 days ago"                  # natural-language dates
-chat-history --source claude                      # claude | cursor | codex
+chat-history --source claude                      # claude | cursor | cursor-agent | codex
 chat-history -L                                   # current workspace only
 chat-history --branch feature-xyz -k "auth" -v    # branch / keyword filters
 
@@ -65,7 +65,7 @@ chat-history inspect --last                # accomplishments, tools, model, toke
 chat-history inspect <partial-uuid>
 chat-history view <id> --plain             # transcript, pipe-friendly (--tools for tool names)
 chat-history export <id> -o session.md
-chat-history resume <id>                   # resume a Claude Code or Codex session
+chat-history resume <id>                   # resume a Claude Code, Cursor Agent, or Codex session
 chat-history find <id>                     # print transcript file path for scripting
 chat-history completions zsh               # shell completions (bash/zsh/fish/elvish/powershell)
 ```
@@ -75,5 +75,7 @@ chat-history completions zsh               # shell completions (bash/zsh/fish/el
 
 ## Interpreting output
 
-- `CC` = Claude Code, `CR` = Cursor, `CX` = Codex; `★ N.N` = relevance score.
+- `claude` = Claude Code, `cursor` = Cursor IDE (Chat/Ask, SQLite), `cursor-agent` = Cursor Agent transcripts, `codex` = Codex; `★ N.N` = relevance score.
+- Header line has `DIR:` (spawn directory) and, for index search, `INDEX_FIELD:` (`summary` / `first_prompt` / `branch`). Title is on the next line. Cursor IDE rows show `00000000` instead of a session id; `resume 00000000` explains how to open the chat in the Cursor IDE UI.
+- `COPIES: N` means the same session id exists in more than one Cursor project folder; `inspect`/`resume`/`find` pick one copy (cwd match, else newest) and print the others.
 - Accepted dates: `YYYY-MM-DD`, `today`, `yesterday`, `"3 days ago"`, `"last week"`, `"last month"`.

--- a/SKILL.md
+++ b/SKILL.md
@@ -27,7 +27,7 @@ Search, inspect, and export Claude Code, Cursor, and Codex conversation history.
 
 1. `chat-history --from yesterday --to yesterday` — every row shows a short session ID; `-s` groups by day for multi-day overviews.
    - `--from X` alone means **X through today**. Always pair with `--to` when the user means a specific day.
-   - Short IDs work everywhere a session ID is accepted (`inspect`, `view`, `resume`, `find`); `-v` adds full IDs and file paths.
+   - Short IDs on `claude` / `codex` / `cursor-agent` rows work with `inspect`, `view`, `resume`, `find`. `cursor-ide` rows hide the id (`--------`); do **not** `resume` them — tell the user the **title** and `DIR:` and to open that folder in Cursor and pick the chat in the sidebar. `-v` / `--json` still have the full id for `inspect` / `view` / `find`.
 2. `chat-history inspect <id>` for accomplishments, tools, files touched.
 
 ## Choosing the best hit
@@ -40,7 +40,8 @@ Search, inspect, and export Claude Code, Cursor, and Codex conversation history.
 
 - Only `search` accepts `--json`; the session list and `inspect` reject it.
 - The only subcommands are `search`, `inspect`, `view`, `export`, `resume`, `find`, `install-skill`, `completions`. Do not guess others; run `chat-history --help` when unsure.
-- Don't dump raw JSON or full transcripts at the user — summarize, cite the session ID and date.
+- Don't dump raw JSON or full transcripts at the user — summarize, cite the session ID and date (or title + directory for `cursor-ide`).
+- Do not `resume` a session whose human tag is `cursor-ide`. `--json` may still report `"source": "cursor"` for IDE Agent chats that also have a jsonl; `resume` will print a sidebar hint instead of launching the Agent CLI.
 - Some Cursor sessions have thin metadata (`(no summary)`, `duration: 0min`, raw first-message titles). If `inspect` is thin, fall back to `chat-history view <id> --plain`.
 
 ## Commands
@@ -65,7 +66,7 @@ chat-history inspect --last                # accomplishments, tools, model, toke
 chat-history inspect <partial-uuid>
 chat-history view <id> --plain             # transcript, pipe-friendly (--tools for tool names)
 chat-history export <id> -o session.md
-chat-history resume <id>                   # resume a Claude Code, Cursor Agent, or Codex session
+chat-history resume <id>                   # Claude Code, Cursor Agent CLI, or Codex — not IDE sidebar
 chat-history find <id>                     # print transcript file path for scripting
 chat-history completions zsh               # shell completions (bash/zsh/fish/elvish/powershell)
 ```
@@ -75,7 +76,7 @@ chat-history completions zsh               # shell completions (bash/zsh/fish/el
 
 ## Interpreting output
 
-- Display tags: `claude` = Claude Code, `cursor-ide` = Cursor IDE sidebar (SQLite; IDE Agent chats also write a jsonl under `agent-transcripts/` with the same id), `cursor-agent` = Cursor Agent CLI / transcript-only jsonl, `codex` = Codex; `★ N.N` = relevance score.
-- Header line has `DIR:` (spawn directory) and, for index search, `INDEX_FIELD:` (`summary` / `first_prompt` / `branch`). Title is on the next line. Claude/Codex/`cursor-agent` short IDs can be passed to `inspect` / `view` / `export` / `find` / `resume`. Rows tagged `cursor-ide` hide the composer UUID and **cannot** be `resume`d from the CLI (prints how to find the chat in the Cursor sidebar), even when an `agent-transcripts` jsonl exists for the same id. `list -v` / JSON still have the id for `inspect` / `view` / `find`.
+- Display tags: `claude` = Claude Code, `cursor-ide` = Cursor IDE sidebar (SQLite; IDE Agent also writes jsonl with the same id — still listed once as `cursor-ide`), `cursor-agent` = Agent CLI / jsonl-only, `codex` = Codex; `★ N.N` = relevance score. `--source cursor` / `cursor-agent` = jsonl store; `--source cursor-ide` = SQLite.
+- Header line has `DIR:` (spawn directory) and, for index search, `INDEX_FIELD:` (`summary` / `first_prompt` / `branch`). Title is on the next line. Pass Claude/Codex/`cursor-agent` short IDs to `inspect` / `view` / `export` / `find` / `resume`. `cursor-ide` rows show `--------`; find them in the sidebar by title + `DIR:`. `list -v` / JSON still have the id.
 - `COPIES: N` means the same Cursor Agent session id exists in more than one project folder; `inspect`/`resume`/`find` pick one copy (cwd match, else newest) and print the others.
 - Accepted dates: `YYYY-MM-DD`, `today`, `yesterday`, `"3 days ago"`, `"last week"`, `"last month"`.

--- a/SKILL.md
+++ b/SKILL.md
@@ -50,7 +50,7 @@ Search, inspect, and export Claude Code, Cursor, and Codex conversation history.
 chat-history                                      # newest first; short IDs on every row (-v for full IDs + paths)
 chat-history --from yesterday --to yesterday -s   # a specific day, grouped
 chat-history --from "3 days ago"                  # natural-language dates
-chat-history --source claude                      # claude | cursor | cursor-agent | codex
+chat-history --source claude                      # claude | cursor | cursor-agent | cursor-ide | codex
 chat-history -L                                   # current workspace only
 chat-history --branch feature-xyz -k "auth" -v    # branch / keyword filters
 
@@ -75,7 +75,7 @@ chat-history completions zsh               # shell completions (bash/zsh/fish/el
 
 ## Interpreting output
 
-- `claude` = Claude Code, `cursor` = Cursor IDE (Chat/Ask, SQLite), `cursor-agent` = Cursor Agent transcripts, `codex` = Codex; `★ N.N` = relevance score.
-- Header line has `DIR:` (spawn directory) and, for index search, `INDEX_FIELD:` (`summary` / `first_prompt` / `branch`). Title is on the next line. Cursor IDE rows show `00000000` instead of a session id; `resume 00000000` explains how to open the chat in the Cursor IDE UI.
-- `COPIES: N` means the same session id exists in more than one Cursor project folder; `inspect`/`resume`/`find` pick one copy (cwd match, else newest) and print the others.
+- `claude` = Claude Code, `cursor` = Cursor Agent transcripts, `cursor-ide` = Cursor IDE SQLite, `codex` = Codex; `★ N.N` = relevance score. `--source cursor-agent` is an alias for `cursor`.
+- Header line has `DIR:` (spawn directory) and, for index search, `INDEX_FIELD:` (`summary` / `first_prompt` / `branch`). Title is on the next line. Every displayed short ID can be passed to `inspect` / `view` / `export` / `find`. `resume` on `cursor-ide` rows prints how to open the chat in the Cursor UI.
+- `COPIES: N` means the same Cursor Agent session id exists in more than one project folder; `inspect`/`resume`/`find` pick one copy (cwd match, else newest) and print the others.
 - Accepted dates: `YYYY-MM-DD`, `today`, `yesterday`, `"3 days ago"`, `"last week"`, `"last month"`.

--- a/SKILL.md
+++ b/SKILL.md
@@ -27,7 +27,7 @@ Search, inspect, and export Claude Code, Cursor, and Codex conversation history.
 
 1. `chat-history --from yesterday --to yesterday` — every row shows a short session ID; `-s` groups by day for multi-day overviews.
    - `--from X` alone means **X through today**. Always pair with `--to` when the user means a specific day.
-   - Short IDs on `claude` / `codex` / `cursor-agent` rows work with `inspect`, `view`, `resume`, `find`. `cursor-ide` rows hide the id (`--------`); do **not** `resume` them — tell the user the **title** and `DIR:` and to open that folder in Cursor and pick the chat in the sidebar. `-v` / `--json` still have the full id for `inspect` / `view` / `find`.
+   - Short IDs work everywhere a session ID is accepted (`inspect`, `view`, `export`, `find`); `-v` adds full IDs and file paths. `resume` works for `claude` / `codex` / `cursor-agent` rows only — do **not** `resume` a `cursor-ide` row; tell the user the **title** and `DIR:` and to open that folder in Cursor and pick the chat in the sidebar.
 2. `chat-history inspect <id>` for accomplishments, tools, files touched.
 
 ## Choosing the best hit
@@ -77,6 +77,6 @@ chat-history completions zsh               # shell completions (bash/zsh/fish/el
 ## Interpreting output
 
 - Display tags: `claude` = Claude Code, `cursor-ide` = Cursor IDE sidebar (SQLite; IDE Agent also writes jsonl with the same id — still listed once as `cursor-ide`), `cursor-agent` = Agent CLI / jsonl-only, `codex` = Codex; `★ N.N` = relevance score. `--source cursor` / `cursor-agent` = jsonl store; `--source cursor-ide` = SQLite.
-- Header line has `DIR:` (spawn directory) and, for index search, `INDEX_FIELD:` (`summary` / `first_prompt` / `branch`). Title is on the next line. Pass Claude/Codex/`cursor-agent` short IDs to `inspect` / `view` / `export` / `find` / `resume`. `cursor-ide` rows show `--------`; find them in the sidebar by title + `DIR:`. `list -v` / JSON still have the id.
+- Header line has `DIR:` (spawn directory) and, for index search, `INDEX_FIELD:` (`summary` / `first_prompt` / `branch`). Title is on the next line. Pass the short ID to `inspect` / `view` / `export` / `find` for any row, and to `resume` for `claude` / `codex` / `cursor-agent` rows. `cursor-ide` rows are found in the sidebar by title + `DIR:`.
 - `COPIES: N` means the same Cursor Agent session id exists in more than one project folder; `inspect`/`resume`/`find` pick one copy (cwd match, else newest) and print the others.
 - Accepted dates: `YYYY-MM-DD`, `today`, `yesterday`, `"3 days ago"`, `"last week"`, `"last month"`.

--- a/SKILL.md
+++ b/SKILL.md
@@ -27,7 +27,7 @@ Search, inspect, and export Claude Code, Cursor, and Codex conversation history.
 
 1. `chat-history --from yesterday --to yesterday` — every row shows a short session ID; `-s` groups by day for multi-day overviews.
    - `--from X` alone means **X through today**. Always pair with `--to` when the user means a specific day.
-   - Short IDs work everywhere a session ID is accepted (`inspect`, `view`, `export`, `find`); `-v` adds full IDs and file paths. `resume` works for `claude` / `codex` / `cursor-agent` rows only — do **not** `resume` a `cursor-ide` row; tell the user the **title** and `DIR:` and to open that folder in Cursor and pick the chat in the sidebar.
+   - Short IDs work everywhere a session ID is accepted (`inspect`, `view`, `export`, `find`); `-v` adds full IDs and file paths. `resume` works for `claude` / `codex` rows and for Cursor Agent CLI chats; `cursor-ide` rows (and Agent transcripts without a CLI store) print the **title** and `DIR:` — tell the user to open that folder in Cursor and pick the chat in the sidebar.
 2. `chat-history inspect <id>` for accomplishments, tools, files touched.
 
 ## Choosing the best hit
@@ -77,6 +77,6 @@ chat-history completions zsh               # shell completions (bash/zsh/fish/el
 ## Interpreting output
 
 - Display tags: `claude` = Claude Code, `cursor-ide` = Cursor IDE sidebar (SQLite; IDE Agent also writes jsonl with the same id — still listed once as `cursor-ide`), `cursor-agent` = Agent CLI / jsonl-only, `codex` = Codex; `★ N.N` = relevance score. `--source cursor` / `cursor-agent` = jsonl store; `--source cursor-ide` = SQLite.
-- Header line has `DIR:` (spawn directory) and, for index search, `INDEX_FIELD:` (`summary` / `first_prompt` / `branch`). Title is on the next line. Pass the short ID to `inspect` / `view` / `export` / `find` for any row, and to `resume` for `claude` / `codex` / `cursor-agent` rows. `cursor-ide` rows are found in the sidebar by title + `DIR:`.
+- Header line has `DIR:` (spawn directory) and, for index search, `INDEX_FIELD:` (`summary` / `first_prompt` / `branch`). Title is on the next line. Pass the short ID to `inspect` / `view` / `export` / `find` for any row, and to `resume` for `claude` / `codex` rows and Cursor Agent CLI chats (`cursor-agent` rows that still have a `~/.cursor/chats` store). Other Cursor rows are found in the sidebar by title + `DIR:`.
 - `COPIES: N` means the same Cursor Agent session id exists in more than one project folder; `inspect`/`resume`/`find` pick one copy (cwd match, else newest) and print the others.
 - Accepted dates: `YYYY-MM-DD`, `today`, `yesterday`, `"3 days ago"`, `"last week"`, `"last month"`.

--- a/src/cursor_ide.rs
+++ b/src/cursor_ide.rs
@@ -183,12 +183,11 @@ fn load_bubble_entries(conn: &Connection, composer_id: &str) -> Vec<Value> {
             if let Some(raw) = kv_blob(conn, &key)
                 && let Ok(mut entry) = serde_json::from_str::<Value>(&raw)
             {
-                if entry.get("type").is_none() {
-                    if let Some(t) = h.get("type") {
-                        entry
-                            .as_object_mut()
-                            .map(|o| o.insert("type".into(), t.clone()));
-                    }
+                if entry.get("type").is_none()
+                    && let Some(t) = h.get("type")
+                    && let Some(obj) = entry.as_object_mut()
+                {
+                    obj.insert("type".into(), t.clone());
                 }
                 entries.push(entry);
             }
@@ -496,20 +495,19 @@ mod tests {
                     "bubbleId:aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee:",
                     "bubbleId:aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee;",
                 ],
-                |row| Ok(row.get::<_, String>(3)?),
+                |row| row.get::<_, String>(3),
             )
             .unwrap()
             .flatten()
             .collect::<Vec<_>>()
             .join(" ");
+        let upper = plan.to_ascii_uppercase();
         assert!(
-            plan.to_ascii_uppercase().contains("SEARCH")
-                || plan.to_ascii_uppercase().contains("INDEX"),
+            upper.contains("SEARCH") && upper.contains("INDEX"),
             "expected index search, got {plan}"
         );
         assert!(
-            !plan.to_ascii_uppercase().contains("SCAN cursorDiskKV")
-                || plan.to_ascii_uppercase().contains("INDEX"),
+            !upper.contains("SCAN CURSORDISKKV"),
             "full table scan: {plan}"
         );
     }

--- a/src/cursor_ide.rs
+++ b/src/cursor_ide.rs
@@ -1,0 +1,322 @@
+//! Cursor IDE chats from `state.vscdb` (SQLite).
+//! Schema is unofficial and can drift with Cursor releases.
+
+use crate::parser::{clean_first_prompt, extract_text, is_clear_metadata, is_warmup_message};
+use crate::session::{Message, Session, user_home};
+use chrono::{TimeZone, Utc};
+use rusqlite::{Connection, OpenFlags};
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+
+pub fn cursor_user_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("CURSOR_USER_DIR")
+        && !dir.is_empty()
+    {
+        return PathBuf::from(dir);
+    }
+    let home = user_home().unwrap_or_else(|| PathBuf::from("."));
+    if cfg!(target_os = "macos") {
+        home.join("Library/Application Support/Cursor/User")
+    } else if cfg!(windows) {
+        std::env::var_os("APPDATA")
+            .map(PathBuf::from)
+            .unwrap_or(home)
+            .join("Cursor/User")
+    } else {
+        home.join(".config/Cursor/User")
+    }
+}
+
+fn global_vscdb() -> PathBuf {
+    cursor_user_dir().join("globalStorage/state.vscdb")
+}
+
+fn open_ro(path: &Path) -> Option<Connection> {
+    let flags = OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI;
+    let uri = format!("file:{}?mode=ro", path.display());
+    Connection::open_with_flags(&uri, flags).ok()
+}
+
+fn ms_iso_date(ms: i64) -> (String, String) {
+    let Some(dt) = Utc.timestamp_millis_opt(ms).single() else {
+        return (String::new(), String::new());
+    };
+    (
+        dt.format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+        dt.format("%Y-%m-%d").to_string(),
+    )
+}
+
+fn workspace_path(value: &Value) -> String {
+    value
+        .pointer("/workspaceIdentifier/uri/fsPath")
+        .or_else(|| value.pointer("/workspaceIdentifier/uri/path"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string()
+}
+
+fn blob_text(value: rusqlite::types::ValueRef<'_>) -> String {
+    match value {
+        rusqlite::types::ValueRef::Text(t) => String::from_utf8_lossy(t).into_owned(),
+        rusqlite::types::ValueRef::Blob(b) => String::from_utf8_lossy(b).into_owned(),
+        _ => String::new(),
+    }
+}
+
+fn first_user_text(conn: &Connection, composer_id: &str) -> String {
+    let pattern = format!("bubbleId:{composer_id}:%");
+    let mut stmt = match conn.prepare("SELECT value FROM cursorDiskKV WHERE key LIKE ?1") {
+        Ok(s) => s,
+        Err(_) => return String::new(),
+    };
+    let rows = stmt.query_map([&pattern], |row| Ok(blob_text(row.get_ref(0)?)));
+    let Ok(rows) = rows else {
+        return String::new();
+    };
+    for val in rows.flatten() {
+        let Ok(entry) = serde_json::from_str::<Value>(&val) else {
+            continue;
+        };
+        if entry.get("type").and_then(Value::as_i64) != Some(1) {
+            continue;
+        }
+        let text = entry
+            .get("text")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        let cleaned = clean_first_prompt(&text);
+        if !cleaned.is_empty() && !is_warmup_message(&cleaned) && !is_clear_metadata(&cleaned) {
+            return cleaned.chars().take(300).collect();
+        }
+    }
+    String::new()
+}
+
+pub fn load_cursor_ide_sessions() -> Vec<Session> {
+    let db = global_vscdb();
+    if !db.exists() {
+        return Vec::new();
+    }
+    let Some(conn) = open_ro(&db) else {
+        return Vec::new();
+    };
+    let mut sessions = Vec::new();
+    let sql = "SELECT composerId, createdAt, lastUpdatedAt, isSubagent, value FROM composerHeaders";
+    let mut stmt = match conn.prepare(sql) {
+        Ok(s) => s,
+        Err(_) => return sessions,
+    };
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, Option<i64>>(1)?.unwrap_or(0),
+            row.get::<_, Option<i64>>(2)?.unwrap_or(0),
+            row.get::<_, i64>(3).unwrap_or(0) != 0,
+            blob_text(row.get_ref(4)?),
+        ))
+    });
+    let Ok(rows) = rows else {
+        return sessions;
+    };
+    let file = db.to_string_lossy().to_string();
+    for row in rows.flatten() {
+        let (id, created_ms, updated_ms, is_sidechain, raw) = row;
+        let meta: Value = serde_json::from_str(&raw).unwrap_or(Value::Null);
+        let name = meta
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        let subtitle = meta
+            .get("subtitle")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        let mut first: String = if !subtitle.is_empty() {
+            subtitle.chars().take(300).collect()
+        } else {
+            name.chars().take(300).collect()
+        };
+        if first.is_empty() {
+            first = first_user_text(&conn, &id);
+        }
+        let ts = if updated_ms > 0 { updated_ms } else { created_ms };
+        let (iso, date) = ms_iso_date(ts);
+        sessions.push(Session {
+            source: "cursor".into(),
+            id,
+            summary: name,
+            first_prompt: first,
+            created: iso.clone(),
+            modified: iso,
+            date,
+            messages: 0,
+            branch: String::new(),
+            project: workspace_path(&meta),
+            file: file.clone(),
+            is_sidechain,
+        });
+    }
+    sessions
+}
+
+pub fn parse_cursor_ide(session: &Session) -> Vec<Message> {
+    let db = Path::new(&session.file);
+    let Some(conn) = open_ro(db) else {
+        return Vec::new();
+    };
+    let pattern = format!("bubbleId:{}:%", session.id);
+    let mut stmt = match conn.prepare("SELECT value FROM cursorDiskKV WHERE key LIKE ?1") {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+    let rows = stmt.query_map([&pattern], |row| Ok(blob_text(row.get_ref(0)?)));
+    let Ok(rows) = rows else {
+        return Vec::new();
+    };
+    let mut messages = Vec::new();
+    let mut total_chars: usize = 0;
+    for val in rows.flatten() {
+        if total_chars > 4 * 1024 * 1024 {
+            break;
+        }
+        let Ok(entry) = serde_json::from_str::<Value>(&val) else {
+            continue;
+        };
+        let ty = entry.get("type").and_then(Value::as_i64).unwrap_or(0);
+        let role = match ty {
+            1 => "user",
+            2 => "assistant",
+            _ => continue,
+        };
+        let text = entry
+            .get("text")
+            .and_then(Value::as_str)
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| {
+                entry
+                    .get("richText")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string()
+            });
+        let cleaned = if role == "user" {
+            crate::parser::clean_prompt(&text)
+        } else {
+            extract_text(&Value::String(text.clone()))
+        };
+        if cleaned.is_empty() {
+            continue;
+        }
+        if role == "user" && (is_warmup_message(&cleaned) || is_clear_metadata(&cleaned)) {
+            continue;
+        }
+        total_chars += cleaned.len();
+        let ts = entry
+            .get("createdAt")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        messages.push(Message {
+            uuid: entry
+                .get("bubbleId")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string(),
+            timestamp: ts,
+            role: role.into(),
+            content: cleaned,
+            session_id: session.id.clone(),
+            project_path: session.project.clone(),
+            tool_uses: Vec::new(),
+            files_referenced: Vec::new(),
+            error_patterns: Vec::new(),
+            relevance_score: 0.0,
+            final_score: 0.0,
+        });
+    }
+    messages
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn fixture_db() -> (tempfile::TempDir, PathBuf) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let user = tmp.path().join("User");
+        let dir = user.join("globalStorage");
+        std::fs::create_dir_all(&dir).unwrap();
+        let db = dir.join("state.vscdb");
+        let conn = Connection::open(&db).unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE composerHeaders (
+                composerId TEXT PRIMARY KEY,
+                workspaceId TEXT,
+                createdAt INTEGER,
+                lastUpdatedAt INTEGER,
+                isArchived INTEGER,
+                isSubagent INTEGER,
+                recency INTEGER,
+                checkpointAt INTEGER,
+                value TEXT
+            );
+            CREATE TABLE cursorDiskKV (key TEXT UNIQUE, value BLOB);
+            "#,
+        )
+        .unwrap();
+        let header = serde_json::json!({
+            "name": "Explain the error handler",
+            "unifiedMode": "agent",
+            "subtitle": "Read src/main.rs",
+            "workspaceIdentifier": {"uri": {"fsPath": "/home/alice/src/myapp", "path": "/home/alice/src/myapp"}}
+        });
+        conn.execute(
+            "INSERT INTO composerHeaders (composerId, createdAt, lastUpdatedAt, isSubagent, value)
+             VALUES (?1, 1782941109570, 1782941109570, 0, ?2)",
+            rusqlite::params!["aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee", header.to_string()],
+        )
+        .unwrap();
+        let bubble = serde_json::json!({
+            "type": 1,
+            "text": "How does the error handler work?",
+            "bubbleId": "b1",
+            "createdAt": "2026-07-01T21:25:09.594Z"
+        });
+        conn.execute(
+            "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+            rusqlite::params![
+                "bubbleId:aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee:b1",
+                bubble.to_string()
+            ],
+        )
+        .unwrap();
+        drop(conn);
+        (tmp, user)
+    }
+
+    #[test]
+    fn loads_ide_chat_from_vscdb() {
+        let (_tmp, user) = fixture_db();
+        unsafe { std::env::set_var("CURSOR_USER_DIR", user.to_str().unwrap()) };
+        let sessions = load_cursor_ide_sessions();
+        unsafe { std::env::remove_var("CURSOR_USER_DIR") };
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].source, "cursor");
+        assert_eq!(sessions[0].summary, "Explain the error handler");
+        assert!(
+            sessions[0].first_prompt.contains("error handler")
+                || sessions[0].first_prompt.contains("main.rs")
+        );
+        assert_eq!(sessions[0].project, "/home/alice/src/myapp");
+        let msgs = parse_cursor_ide(&sessions[0]);
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].role, "user");
+    }
+}

--- a/src/cursor_ide.rs
+++ b/src/cursor_ide.rs
@@ -210,8 +210,8 @@ fn load_bubble_entries(conn: &Connection, composer_id: &str) -> Vec<Value> {
     entries
 }
 
-fn first_user_text(conn: &Connection, composer_id: &str) -> String {
-    if let Some(headers) = composer_header_order(conn, composer_id) {
+fn first_user_text(conn: &Connection, composer_id: &str, headers: Option<&[Value]>) -> String {
+    if let Some(headers) = headers {
         for h in headers {
             if h.get("type").and_then(Value::as_i64) != Some(1) {
                 continue;
@@ -305,12 +305,6 @@ fn bubble_counts(conn: &Connection) -> HashMap<String, u64> {
     counts
 }
 
-fn header_len(conn: &Connection, composer_id: &str) -> u64 {
-    composer_header_order(conn, composer_id)
-        .map(|h| h.len() as u64)
-        .unwrap_or(0)
-}
-
 pub fn load_cursor_ide_sessions() -> Vec<Session> {
     load_cursor_ide_sessions_from(&global_vscdb())
 }
@@ -362,9 +356,13 @@ fn load_cursor_ide_sessions_from(db: &Path) -> Vec<Session> {
         } else {
             name.chars().take(300).collect()
         };
-        let nmsg = header_len(&conn, &id).max(counts.get(&id).copied().unwrap_or(0));
+        // composerData blobs are large (tens of MB across a real DB); read
+        // and parse each one once per listing.
+        let headers = composer_header_order(&conn, &id);
+        let header_len = headers.as_ref().map(|h| h.len() as u64).unwrap_or(0);
+        let nmsg = header_len.max(counts.get(&id).copied().unwrap_or(0));
         if first.is_empty() && nmsg > 0 {
-            first = first_user_text(&conn, &id);
+            first = first_user_text(&conn, &id, headers.as_deref());
         }
         let ts = if updated_ms > 0 {
             updated_ms

--- a/src/cursor_ide.rs
+++ b/src/cursor_ide.rs
@@ -259,6 +259,7 @@ fn first_user_text(conn: &Connection, composer_id: &str) -> String {
         project: String::new(),
         file: String::new(),
         is_sidechain: false,
+        also_ide: false,
     };
     load_bubbles_as_messages(conn, &stub)
         .into_iter()
@@ -382,6 +383,7 @@ fn load_cursor_ide_sessions_from(db: &Path) -> Vec<Session> {
             project: workspace_path(&meta),
             file: file.clone(),
             is_sidechain,
+            also_ide: false,
         });
     }
     sessions
@@ -548,6 +550,7 @@ mod tests {
             project: String::new(),
             file: db.to_string_lossy().into(),
             is_sidechain: false,
+            also_ide: false,
         };
         let msgs = parse_cursor_ide(&session);
         assert_eq!(msgs[0].role, "user");
@@ -603,6 +606,7 @@ mod tests {
             project: String::new(),
             file: db.to_string_lossy().into(),
             is_sidechain: false,
+            also_ide: false,
         };
         let msgs = parse_cursor_ide(&session);
         assert_eq!(msgs.len(), 3);

--- a/src/cursor_ide.rs
+++ b/src/cursor_ide.rs
@@ -146,12 +146,11 @@ fn sort_messages_stable(messages: &mut [Message]) {
 
 fn load_bubbles_range(conn: &Connection, composer_id: &str) -> Vec<Value> {
     let (lower, upper) = bubble_key_bounds(composer_id);
-    let mut stmt = match conn.prepare_cached(
-        "SELECT value FROM cursorDiskKV WHERE key >= ?1 AND key < ?2",
-    ) {
-        Ok(s) => s,
-        Err(_) => return Vec::new(),
-    };
+    let mut stmt =
+        match conn.prepare_cached("SELECT value FROM cursorDiskKV WHERE key >= ?1 AND key < ?2") {
+            Ok(s) => s,
+            Err(_) => return Vec::new(),
+        };
     let rows = stmt.query_map(rusqlite::params![lower, upper], |row| {
         Ok(blob_text(row.get_ref(0)?))
     });
@@ -368,7 +367,11 @@ fn load_cursor_ide_sessions_from(db: &Path) -> Vec<Session> {
         if first.is_empty() && nmsg > 0 {
             first = first_user_text(&conn, &id);
         }
-        let ts = if updated_ms > 0 { updated_ms } else { created_ms };
+        let ts = if updated_ms > 0 {
+            updated_ms
+        } else {
+            created_ms
+        };
         let (iso, date) = ms_iso_date(ts);
         sessions.push(Session {
             source: "cursor-ide".into(),
@@ -483,12 +486,18 @@ mod tests {
         let (_tmp, db) = fixture_db();
         let conn = Connection::open(&db).unwrap();
         let mut stmt = conn
-            .prepare("EXPLAIN QUERY PLAN SELECT value FROM cursorDiskKV WHERE key >= ?1 AND key < ?2")
+            .prepare(
+                "EXPLAIN QUERY PLAN SELECT value FROM cursorDiskKV WHERE key >= ?1 AND key < ?2",
+            )
             .unwrap();
         let plan: String = stmt
-            .query_map(["bubbleId:aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee:", "bubbleId:aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee;"], |row| {
-                Ok(row.get::<_, String>(3)?)
-            })
+            .query_map(
+                [
+                    "bubbleId:aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee:",
+                    "bubbleId:aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee;",
+                ],
+                |row| Ok(row.get::<_, String>(3)?),
+            )
             .unwrap()
             .flatten()
             .collect::<Vec<_>>()

--- a/src/cursor_ide.rs
+++ b/src/cursor_ide.rs
@@ -2,10 +2,11 @@
 //! Schema is unofficial and can drift with Cursor releases.
 
 use crate::parser::{clean_first_prompt, extract_text, is_clear_metadata, is_warmup_message};
-use crate::session::{Message, Session, user_home};
+use crate::session::{Message, Session, parse_any_timestamp, user_home};
 use chrono::{TimeZone, Utc};
 use rusqlite::{Connection, OpenFlags};
 use serde_json::Value;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 pub fn cursor_user_dir() -> PathBuf {
@@ -32,9 +33,7 @@ fn global_vscdb() -> PathBuf {
 }
 
 fn open_ro(path: &Path) -> Option<Connection> {
-    let flags = OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI;
-    let uri = format!("file:{}?mode=ro", path.display());
-    Connection::open_with_flags(&uri, flags).ok()
+    Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY).ok()
 }
 
 fn ms_iso_date(ms: i64) -> (String, String) {
@@ -47,7 +46,7 @@ fn ms_iso_date(ms: i64) -> (String, String) {
     )
 }
 
-fn workspace_path(value: &Value) -> String {
+pub fn workspace_path(value: &Value) -> String {
     value
         .pointer("/workspaceIdentifier/uri/fsPath")
         .or_else(|| value.pointer("/workspaceIdentifier/uri/path"))
@@ -64,42 +63,264 @@ fn blob_text(value: rusqlite::types::ValueRef<'_>) -> String {
     }
 }
 
-fn first_user_text(conn: &Connection, composer_id: &str) -> String {
-    let pattern = format!("bubbleId:{composer_id}:%");
-    let mut stmt = match conn.prepare("SELECT value FROM cursorDiskKV WHERE key LIKE ?1") {
-        Ok(s) => s,
-        Err(_) => return String::new(),
+fn bubble_text(entry: &Value) -> &str {
+    entry
+        .get("text")
+        .and_then(Value::as_str)
+        .filter(|text| !text.is_empty())
+        .or_else(|| entry.get("richText").and_then(Value::as_str))
+        .unwrap_or("")
+}
+
+fn bubble_key_bounds(composer_id: &str) -> (String, String) {
+    (
+        format!("bubbleId:{composer_id}:"),
+        format!("bubbleId:{composer_id};"),
+    )
+}
+
+fn kv_blob(conn: &Connection, key: &str) -> Option<String> {
+    let mut stmt = conn
+        .prepare_cached("SELECT value FROM cursorDiskKV WHERE key = ?1")
+        .ok()?;
+    stmt.query_row([key], |row| Ok(blob_text(row.get_ref(0)?)))
+        .ok()
+}
+
+fn message_from_bubble(session: &Session, entry: &Value) -> Option<Message> {
+    let ty = entry.get("type").and_then(Value::as_i64).unwrap_or(0);
+    let role = match ty {
+        1 => "user",
+        2 => "assistant",
+        _ => return None,
     };
-    let rows = stmt.query_map([&pattern], |row| Ok(blob_text(row.get_ref(0)?)));
-    let Ok(rows) = rows else {
-        return String::new();
+    let text = bubble_text(entry);
+    let cleaned = if role == "user" {
+        crate::parser::clean_prompt(text)
+    } else {
+        extract_text(&Value::String(text.to_string()))
     };
-    for val in rows.flatten() {
-        let Ok(entry) = serde_json::from_str::<Value>(&val) else {
-            continue;
-        };
-        if entry.get("type").and_then(Value::as_i64) != Some(1) {
-            continue;
-        }
-        let text = entry
-            .get("text")
+    if cleaned.is_empty() {
+        return None;
+    }
+    if role == "user" && (is_warmup_message(&cleaned) || is_clear_metadata(&cleaned)) {
+        return None;
+    }
+    let ts = entry
+        .get("createdAt")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    Some(Message {
+        uuid: entry
+            .get("bubbleId")
             .and_then(Value::as_str)
             .unwrap_or("")
-            .to_string();
-        let cleaned = clean_first_prompt(&text);
-        if !cleaned.is_empty() && !is_warmup_message(&cleaned) && !is_clear_metadata(&cleaned) {
-            return cleaned.chars().take(300).collect();
+            .to_string(),
+        timestamp: ts,
+        role: role.into(),
+        content: cleaned,
+        session_id: session.id.clone(),
+        project_path: session.project.clone(),
+        tool_uses: Vec::new(),
+        files_referenced: Vec::new(),
+        error_patterns: Vec::new(),
+        relevance_score: 0.0,
+        final_score: 0.0,
+    })
+}
+
+fn sort_messages_stable(messages: &mut [Message]) {
+    messages.sort_by(|a, b| {
+        match (
+            parse_any_timestamp(&a.timestamp),
+            parse_any_timestamp(&b.timestamp),
+        ) {
+            (Some(a), Some(b)) => a.cmp(&b),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => std::cmp::Ordering::Equal,
+        }
+    });
+}
+
+fn load_bubbles_range(conn: &Connection, composer_id: &str) -> Vec<Value> {
+    let (lower, upper) = bubble_key_bounds(composer_id);
+    let mut stmt = match conn.prepare_cached(
+        "SELECT value FROM cursorDiskKV WHERE key >= ?1 AND key < ?2",
+    ) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+    let rows = stmt.query_map(rusqlite::params![lower, upper], |row| {
+        Ok(blob_text(row.get_ref(0)?))
+    });
+    let Ok(rows) = rows else {
+        return Vec::new();
+    };
+    rows.flatten()
+        .filter_map(|val| serde_json::from_str::<Value>(&val).ok())
+        .collect()
+}
+
+fn composer_header_order(conn: &Connection, composer_id: &str) -> Option<Vec<Value>> {
+    let raw = kv_blob(conn, &format!("composerData:{composer_id}"))?;
+    let data: Value = serde_json::from_str(&raw).ok()?;
+    let headers = data.get("fullConversationHeadersOnly")?.as_array()?;
+    if headers.is_empty() {
+        return None;
+    }
+    Some(headers.clone())
+}
+
+fn load_bubble_entries(conn: &Connection, composer_id: &str) -> Vec<Value> {
+    if let Some(headers) = composer_header_order(conn, composer_id) {
+        let mut entries = Vec::new();
+        for h in headers {
+            let Some(bid) = h.get("bubbleId").and_then(Value::as_str) else {
+                continue;
+            };
+            let key = format!("bubbleId:{composer_id}:{bid}");
+            if let Some(raw) = kv_blob(conn, &key)
+                && let Ok(mut entry) = serde_json::from_str::<Value>(&raw)
+            {
+                if entry.get("type").is_none() {
+                    if let Some(t) = h.get("type") {
+                        entry
+                            .as_object_mut()
+                            .map(|o| o.insert("type".into(), t.clone()));
+                    }
+                }
+                entries.push(entry);
+            }
+        }
+        if !entries.is_empty() {
+            return entries;
         }
     }
-    String::new()
+    let mut entries = load_bubbles_range(conn, composer_id);
+    entries.sort_by(|a, b| {
+        let ta = a.get("createdAt").and_then(Value::as_str).unwrap_or("");
+        let tb = b.get("createdAt").and_then(Value::as_str).unwrap_or("");
+        match (parse_any_timestamp(ta), parse_any_timestamp(tb)) {
+            (Some(a), Some(b)) => a.cmp(&b),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => std::cmp::Ordering::Equal,
+        }
+    });
+    entries
+}
+
+fn first_user_text(conn: &Connection, composer_id: &str) -> String {
+    if let Some(headers) = composer_header_order(conn, composer_id) {
+        for h in headers {
+            if h.get("type").and_then(Value::as_i64) != Some(1) {
+                continue;
+            }
+            let preview = h
+                .pointer("/grouping/textPreview")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .trim();
+            if !preview.is_empty() {
+                let cleaned = clean_first_prompt(preview);
+                if !cleaned.is_empty()
+                    && !is_warmup_message(&cleaned)
+                    && !is_clear_metadata(&cleaned)
+                {
+                    return cleaned.chars().take(300).collect();
+                }
+            }
+            if let Some(bid) = h.get("bubbleId").and_then(Value::as_str)
+                && let Some(raw) = kv_blob(conn, &format!("bubbleId:{composer_id}:{bid}"))
+                && let Ok(entry) = serde_json::from_str::<Value>(&raw)
+            {
+                let cleaned = clean_first_prompt(bubble_text(&entry));
+                if !cleaned.is_empty()
+                    && !is_warmup_message(&cleaned)
+                    && !is_clear_metadata(&cleaned)
+                {
+                    return cleaned.chars().take(300).collect();
+                }
+            }
+        }
+    }
+    let stub = Session {
+        source: "cursor-ide".into(),
+        id: composer_id.into(),
+        summary: String::new(),
+        first_prompt: String::new(),
+        created: String::new(),
+        modified: String::new(),
+        date: String::new(),
+        messages: 0,
+        branch: String::new(),
+        project: String::new(),
+        file: String::new(),
+        is_sidechain: false,
+    };
+    load_bubbles_as_messages(conn, &stub)
+        .into_iter()
+        .find(|m| m.role == "user")
+        .map(|m| m.content.chars().take(300).collect())
+        .unwrap_or_default()
+}
+
+fn load_bubbles_as_messages(conn: &Connection, session: &Session) -> Vec<Message> {
+    let mut messages = Vec::new();
+    let mut total_chars: usize = 0;
+    for entry in load_bubble_entries(conn, &session.id) {
+        if total_chars > 4 * 1024 * 1024 {
+            break;
+        }
+        let Some(msg) = message_from_bubble(session, &entry) else {
+            continue;
+        };
+        total_chars += msg.content.len();
+        messages.push(msg);
+    }
+    if composer_header_order(conn, &session.id).is_none() {
+        sort_messages_stable(&mut messages);
+    }
+    messages
+}
+
+fn bubble_counts(conn: &Connection) -> HashMap<String, u64> {
+    let mut counts = HashMap::new();
+    let mut stmt = match conn.prepare(
+        "SELECT substr(key, 10, 36), count(*) FROM cursorDiskKV \
+         WHERE key >= 'bubbleId:' AND key < 'bubbleId;' GROUP BY 1",
+    ) {
+        Ok(s) => s,
+        Err(_) => return counts,
+    };
+    let rows = stmt.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)? as u64))
+    });
+    if let Ok(rows) = rows {
+        for row in rows.flatten() {
+            counts.insert(row.0, row.1);
+        }
+    }
+    counts
+}
+
+fn header_len(conn: &Connection, composer_id: &str) -> u64 {
+    composer_header_order(conn, composer_id)
+        .map(|h| h.len() as u64)
+        .unwrap_or(0)
 }
 
 pub fn load_cursor_ide_sessions() -> Vec<Session> {
-    let db = global_vscdb();
+    load_cursor_ide_sessions_from(&global_vscdb())
+}
+
+fn load_cursor_ide_sessions_from(db: &Path) -> Vec<Session> {
     if !db.exists() {
         return Vec::new();
     }
-    let Some(conn) = open_ro(&db) else {
+    let Some(conn) = open_ro(db) else {
         return Vec::new();
     };
     let mut sessions = Vec::new();
@@ -120,6 +341,7 @@ pub fn load_cursor_ide_sessions() -> Vec<Session> {
     let Ok(rows) = rows else {
         return sessions;
     };
+    let counts = bubble_counts(&conn);
     let file = db.to_string_lossy().to_string();
     for row in rows.flatten() {
         let (id, created_ms, updated_ms, is_sidechain, raw) = row;
@@ -141,20 +363,21 @@ pub fn load_cursor_ide_sessions() -> Vec<Session> {
         } else {
             name.chars().take(300).collect()
         };
-        if first.is_empty() {
+        let nmsg = header_len(&conn, &id).max(counts.get(&id).copied().unwrap_or(0));
+        if first.is_empty() && nmsg > 0 {
             first = first_user_text(&conn, &id);
         }
         let ts = if updated_ms > 0 { updated_ms } else { created_ms };
         let (iso, date) = ms_iso_date(ts);
         sessions.push(Session {
-            source: "cursor".into(),
+            source: "cursor-ide".into(),
             id,
             summary: name,
             first_prompt: first,
             created: iso.clone(),
             modified: iso,
             date,
-            messages: 0,
+            messages: nmsg,
             branch: String::new(),
             project: workspace_path(&meta),
             file: file.clone(),
@@ -169,77 +392,7 @@ pub fn parse_cursor_ide(session: &Session) -> Vec<Message> {
     let Some(conn) = open_ro(db) else {
         return Vec::new();
     };
-    let pattern = format!("bubbleId:{}:%", session.id);
-    let mut stmt = match conn.prepare("SELECT value FROM cursorDiskKV WHERE key LIKE ?1") {
-        Ok(s) => s,
-        Err(_) => return Vec::new(),
-    };
-    let rows = stmt.query_map([&pattern], |row| Ok(blob_text(row.get_ref(0)?)));
-    let Ok(rows) = rows else {
-        return Vec::new();
-    };
-    let mut messages = Vec::new();
-    let mut total_chars: usize = 0;
-    for val in rows.flatten() {
-        if total_chars > 4 * 1024 * 1024 {
-            break;
-        }
-        let Ok(entry) = serde_json::from_str::<Value>(&val) else {
-            continue;
-        };
-        let ty = entry.get("type").and_then(Value::as_i64).unwrap_or(0);
-        let role = match ty {
-            1 => "user",
-            2 => "assistant",
-            _ => continue,
-        };
-        let text = entry
-            .get("text")
-            .and_then(Value::as_str)
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| {
-                entry
-                    .get("richText")
-                    .and_then(Value::as_str)
-                    .unwrap_or("")
-                    .to_string()
-            });
-        let cleaned = if role == "user" {
-            crate::parser::clean_prompt(&text)
-        } else {
-            extract_text(&Value::String(text.clone()))
-        };
-        if cleaned.is_empty() {
-            continue;
-        }
-        if role == "user" && (is_warmup_message(&cleaned) || is_clear_metadata(&cleaned)) {
-            continue;
-        }
-        total_chars += cleaned.len();
-        let ts = entry
-            .get("createdAt")
-            .and_then(Value::as_str)
-            .unwrap_or("")
-            .to_string();
-        messages.push(Message {
-            uuid: entry
-                .get("bubbleId")
-                .and_then(Value::as_str)
-                .unwrap_or("")
-                .to_string(),
-            timestamp: ts,
-            role: role.into(),
-            content: cleaned,
-            session_id: session.id.clone(),
-            project_path: session.project.clone(),
-            tool_uses: Vec::new(),
-            files_referenced: Vec::new(),
-            error_patterns: Vec::new(),
-            relevance_score: 0.0,
-            final_score: 0.0,
-        });
-    }
-    messages
+    load_bubbles_as_messages(&conn, session)
 }
 
 #[cfg(test)]
@@ -247,13 +400,7 @@ mod tests {
     use super::*;
     use rusqlite::Connection;
 
-    fn fixture_db() -> (tempfile::TempDir, PathBuf) {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let user = tmp.path().join("User");
-        let dir = user.join("globalStorage");
-        std::fs::create_dir_all(&dir).unwrap();
-        let db = dir.join("state.vscdb");
-        let conn = Connection::open(&db).unwrap();
+    fn empty_schema(conn: &Connection) {
         conn.execute_batch(
             r#"
             CREATE TABLE composerHeaders (
@@ -271,6 +418,16 @@ mod tests {
             "#,
         )
         .unwrap();
+    }
+
+    fn fixture_db() -> (tempfile::TempDir, PathBuf) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let user = tmp.path().join("User");
+        let dir = user.join("globalStorage");
+        std::fs::create_dir_all(&dir).unwrap();
+        let db = dir.join("state.vscdb");
+        let conn = Connection::open(&db).unwrap();
+        empty_schema(&conn);
         let header = serde_json::json!({
             "name": "Explain the error handler",
             "unifiedMode": "agent",
@@ -298,25 +455,209 @@ mod tests {
         )
         .unwrap();
         drop(conn);
-        (tmp, user)
+        (tmp, db)
     }
 
     #[test]
     fn loads_ide_chat_from_vscdb() {
-        let (_tmp, user) = fixture_db();
-        unsafe { std::env::set_var("CURSOR_USER_DIR", user.to_str().unwrap()) };
-        let sessions = load_cursor_ide_sessions();
-        unsafe { std::env::remove_var("CURSOR_USER_DIR") };
+        let (_tmp, db) = fixture_db();
+        let sessions = load_cursor_ide_sessions_from(&db);
         assert_eq!(sessions.len(), 1);
-        assert_eq!(sessions[0].source, "cursor");
+        assert_eq!(sessions[0].source, "cursor-ide");
         assert_eq!(sessions[0].summary, "Explain the error handler");
         assert!(
             sessions[0].first_prompt.contains("error handler")
                 || sessions[0].first_prompt.contains("main.rs")
         );
         assert_eq!(sessions[0].project, "/home/alice/src/myapp");
+        assert!(sessions[0].messages >= 1);
         let msgs = parse_cursor_ide(&sessions[0]);
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].role, "user");
+    }
+
+    #[test]
+    fn range_query_uses_index() {
+        let (_tmp, db) = fixture_db();
+        let conn = Connection::open(&db).unwrap();
+        let mut stmt = conn
+            .prepare("EXPLAIN QUERY PLAN SELECT value FROM cursorDiskKV WHERE key >= ?1 AND key < ?2")
+            .unwrap();
+        let plan: String = stmt
+            .query_map(["bubbleId:aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee:", "bubbleId:aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee;"], |row| {
+                Ok(row.get::<_, String>(3)?)
+            })
+            .unwrap()
+            .flatten()
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(
+            plan.to_ascii_uppercase().contains("SEARCH")
+                || plan.to_ascii_uppercase().contains("INDEX"),
+            "expected index search, got {plan}"
+        );
+        assert!(
+            !plan.to_ascii_uppercase().contains("SCAN cursorDiskKV")
+                || plan.to_ascii_uppercase().contains("INDEX"),
+            "full table scan: {plan}"
+        );
+    }
+
+    #[test]
+    fn sorts_bubbles_by_created_at_not_insert_order() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db = tmp.path().join("state.vscdb");
+        let conn = Connection::open(&db).unwrap();
+        empty_schema(&conn);
+        let id = "bbbb2222-cccc-dddd-eeee-ffffffffffff";
+        conn.execute(
+            "INSERT INTO composerHeaders (composerId, createdAt, lastUpdatedAt, isSubagent, value)
+             VALUES (?1, 1, 1, 0, '{}')",
+            [id],
+        )
+        .unwrap();
+        let assistant = serde_json::json!({
+            "type": 2, "text": "later assistant", "bubbleId": "a",
+            "createdAt": "2026-08-01T10:00:05Z"
+        });
+        let user = serde_json::json!({
+            "type": 1, "text": "earlier user prompt here", "bubbleId": "u",
+            "createdAt": "2026-08-01T10:00:00Z"
+        });
+        conn.execute(
+            "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+            rusqlite::params![format!("bubbleId:{id}:a"), assistant.to_string()],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+            rusqlite::params![format!("bubbleId:{id}:u"), user.to_string()],
+        )
+        .unwrap();
+        drop(conn);
+        let session = Session {
+            source: "cursor-ide".into(),
+            id: id.into(),
+            summary: String::new(),
+            first_prompt: String::new(),
+            created: String::new(),
+            modified: String::new(),
+            date: String::new(),
+            messages: 0,
+            branch: String::new(),
+            project: String::new(),
+            file: db.to_string_lossy().into(),
+            is_sidechain: false,
+        };
+        let msgs = parse_cursor_ide(&session);
+        assert_eq!(msgs[0].role, "user");
+        assert_eq!(msgs[1].role, "assistant");
+    }
+
+    #[test]
+    fn prefers_composer_data_header_order() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db = tmp.path().join("state.vscdb");
+        let conn = Connection::open(&db).unwrap();
+        empty_schema(&conn);
+        let id = "cccc3333-dddd-eeee-ffff-111111111111";
+        conn.execute(
+            "INSERT INTO composerHeaders (composerId, createdAt, lastUpdatedAt, isSubagent, value)
+             VALUES (?1, 1, 1, 0, '{}')",
+            [id],
+        )
+        .unwrap();
+        let u1 = serde_json::json!({"type": 1, "text": "first user message body", "bubbleId": "u1", "createdAt": "2026-08-01T10:01:00Z"});
+        let a1 = serde_json::json!({"type": 2, "text": "assistant reply body", "bubbleId": "a1", "createdAt": "2026-08-01T10:00:05Z"});
+        let u2 = serde_json::json!({"type": 1, "text": "second user message body", "bubbleId": "u2", "createdAt": "2026-08-01T09:00:00Z"});
+        for (k, v) in [("u1", &u1), ("a1", &a1), ("u2", &u2)] {
+            conn.execute(
+                "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+                rusqlite::params![format!("bubbleId:{id}:{k}"), v.to_string()],
+            )
+            .unwrap();
+        }
+        let data = serde_json::json!({
+            "fullConversationHeadersOnly": [
+                {"bubbleId": "u1", "type": 1, "createdAt": "2026-08-01T10:00:00Z"},
+                {"bubbleId": "a1", "type": 2, "createdAt": "2026-08-01T10:00:05Z"},
+                {"bubbleId": "u2", "type": 1, "createdAt": "2026-08-01T10:01:00Z"}
+            ]
+        });
+        conn.execute(
+            "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+            rusqlite::params![format!("composerData:{id}"), data.to_string()],
+        )
+        .unwrap();
+        drop(conn);
+        let session = Session {
+            source: "cursor-ide".into(),
+            id: id.into(),
+            summary: String::new(),
+            first_prompt: String::new(),
+            created: String::new(),
+            modified: String::new(),
+            date: String::new(),
+            messages: 0,
+            branch: String::new(),
+            project: String::new(),
+            file: db.to_string_lossy().into(),
+            is_sidechain: false,
+        };
+        let msgs = parse_cursor_ide(&session);
+        assert_eq!(msgs.len(), 3);
+        assert!(msgs[0].content.contains("first user"));
+        assert!(msgs[1].content.contains("assistant"));
+        assert!(msgs[2].content.contains("second user"));
+    }
+
+    #[test]
+    fn rich_text_only_bubble_is_indexed() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db = tmp.path().join("state.vscdb");
+        let conn = Connection::open(&db).unwrap();
+        empty_schema(&conn);
+        let id = "dddd4444-eeee-ffff-aaaa-222222222222";
+        conn.execute(
+            "INSERT INTO composerHeaders (composerId, createdAt, lastUpdatedAt, isSubagent, value)
+             VALUES (?1, 1, 1, 0, '{\"name\":\"\"}')",
+            [id],
+        )
+        .unwrap();
+        let bubble = serde_json::json!({
+            "type": 1, "text": "", "richText": "please explain the cache layer design",
+            "bubbleId": "r1", "createdAt": "2026-08-01T10:00:00Z"
+        });
+        conn.execute(
+            "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+            rusqlite::params![format!("bubbleId:{id}:r1"), bubble.to_string()],
+        )
+        .unwrap();
+        drop(conn);
+        let sessions = load_cursor_ide_sessions_from(&db);
+        assert_eq!(sessions.len(), 1);
+        assert!(sessions[0].first_prompt.contains("cache layer"));
+        let msgs = parse_cursor_ide(&sessions[0]);
+        assert_eq!(msgs[0].content, "please explain the cache layer design");
+    }
+
+    #[test]
+    fn opens_db_when_path_contains_hash() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path().join("cursor#profile").join("globalStorage");
+        std::fs::create_dir_all(&dir).unwrap();
+        let db = dir.join("state.vscdb");
+        let conn = Connection::open(&db).unwrap();
+        empty_schema(&conn);
+        conn.execute(
+            "INSERT INTO composerHeaders (composerId, createdAt, lastUpdatedAt, isSubagent, value)
+             VALUES ('eeee5555-ffff-aaaa-bbbb-333333333333', 1, 1, 0, '{\"name\":\"hash path\"}')",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+        let sessions = load_cursor_ide_sessions_from(&db);
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].summary, "hash path");
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -123,13 +123,10 @@ fn print_title_line(title: &str) {
     println!("        {}{}{}", c!("bold"), title, c!("reset"));
 }
 
-/// Dim 8-char session-id chip. Claude/Codex/Agent-CLI prefixes resolve via
-/// inspect/view/export/resume/find. Rows tagged `cursor-ide` omit the prefix
-/// (not shown in the Cursor sidebar). `list -v` still prints the full id.
+/// Dim 8-char session-id chip. Every row shows it: the prefix resolves via
+/// inspect/view/export/find for all sources, and via resume for everything
+/// except `cursor-ide` rows (those print a sidebar hint instead).
 fn id_chip(session: &Session) -> String {
-    if session.is_ide_ui() {
-        return format!("{}--------{}", c!("dim"), c!("reset"));
-    }
     let short: String = session.id.chars().take(8).collect();
     format!("{}{:8}{}", c!("dim"), short, c!("reset"))
 }
@@ -730,7 +727,7 @@ mod tests {
     }
 
     #[test]
-    fn id_chip_hides_ide_composer_prefix() {
+    fn id_chip_shows_prefix_for_ide_rows_too() {
         let ide = Session {
             source: "cursor-ide".into(),
             id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".into(),
@@ -751,13 +748,12 @@ mod tests {
             id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".into(),
             ..ide.clone()
         };
-        assert!(super::id_chip(&ide).contains("--------"));
-        assert!(!super::id_chip(&ide).contains("aaaaaaaa"));
+        assert!(super::id_chip(&ide).contains("aaaaaaaa"));
         assert!(super::id_chip(&agent).contains("aaaaaaaa"));
         agent.also_ide = true;
         assert!(super::src_tag("cursor", true).contains("cursor-ide"));
-        assert!(super::id_chip(&agent).contains("--------"));
-        assert!(!super::id_chip(&agent).contains("aaaaaaaa"));
+        assert!(super::id_chip(&agent).contains("aaaaaaaa"));
+        assert!(!super::id_chip(&agent).contains("--------"));
     }
 
     #[test]

--- a/src/display.rs
+++ b/src/display.rs
@@ -27,6 +27,7 @@ macro_rules! c {
                 "bg_blue" => "\x1b[44m",
                 "bg_magenta" => "\x1b[45m",
                 "bg_cyan" => "\x1b[46m",
+                "bg_yellow" => "\x1b[43m",
                 _ => "",
             }
         } else {
@@ -39,13 +40,13 @@ fn src_tag(source: &str) -> String {
     let label = match source {
         "claude" => "claude",
         "codex" => "codex",
-        "cursor" => "cursor",
-        _ => "cursor-agent",
+        "cursor-ide" => "cursor-ide",
+        _ => "cursor",
     };
     let color = match source {
         "claude" => "bg_cyan",
         "codex" => "bg_magenta",
-        "cursor" => "bg_blue",
+        "cursor-ide" => "bg_yellow",
         _ => "bg_blue",
     };
     format!("{}{} {:<12} {}", c!(color), c!("bold"), label, c!("reset"))
@@ -87,8 +88,11 @@ fn dir_label(project: &str) -> String {
     labeled("DIR", &abbreviate_home(project))
 }
 
-fn copies_label(sessions: &[Session], s: &Session) -> String {
-    let n = session::copy_count(sessions, s);
+fn copies_label(counts: &std::collections::HashMap<(String, String), usize>, s: &Session) -> String {
+    let n = counts
+        .get(&(s.source.clone(), s.id.to_ascii_lowercase()))
+        .copied()
+        .unwrap_or(0);
     if n > 1 {
         labeled("COPIES", &n.to_string())
     } else {
@@ -96,31 +100,27 @@ fn copies_label(sessions: &[Session], s: &Session) -> String {
     }
 }
 
+fn copy_counts(sessions: &[Session]) -> std::collections::HashMap<(String, String), usize> {
+    let mut m = std::collections::HashMap::new();
+    for s in sessions {
+        if s.source != "cursor" {
+            continue;
+        }
+        *m.entry((s.source.clone(), s.id.to_ascii_lowercase()))
+            .or_insert(0) += 1;
+    }
+    m
+}
+
 fn print_title_line(title: &str) {
     println!("        {}{}{}", c!("bold"), title, c!("reset"));
 }
 
-/// Dim 8-char session-id chip. IDE (`cursor`) chats aren't CLI-resumable,
-/// so they show a placeholder instead of the composer UUID.
+/// Dim 8-char session-id chip. Every prefix resolves via inspect/view/
+/// export/resume/find.
 fn id_chip(session: &Session) -> String {
-    let short = display_id(&session.source, &session.id);
+    let short: String = session.id.chars().take(8).collect();
     format!("{}{:8}{}", c!("dim"), short, c!("reset"))
-}
-
-fn display_id(source: &str, id: &str) -> String {
-    if source == "cursor" {
-        "00000000".into()
-    } else {
-        id.chars().take(8).collect()
-    }
-}
-
-fn display_full_id(source: &str, id: &str) -> String {
-    if source == "cursor" {
-        "00000000".into()
-    } else {
-        id.to_string()
-    }
 }
 
 /// Best one-line title for a session: summary, else cleaned first prompt.
@@ -147,6 +147,7 @@ pub fn print_list(sessions: &[Session], verbose: bool) {
         sessions.len(),
         c!("reset")
     );
+    let counts = copy_counts(sessions);
     for (i, s) in sessions.iter().enumerate() {
         let tag = src_tag(&s.source);
         let title = title_of(&s.summary, &s.first_prompt, 100);
@@ -172,14 +173,14 @@ pub fn print_list(sessions: &[Session], verbose: bool) {
             c!("reset"),
             id_chip(s),
             dir_label(&s.project),
-            copies_label(sessions, s),
+            copies_label(&counts, s),
             sidechain,
             branch,
             msgs
         );
         print_title_line(&title);
         if verbose {
-            println!("       {}id: {}{}", c!("dim"), display_full_id(&s.source, &s.id), c!("reset"));
+            println!("       {}id: {}{}", c!("dim"), s.id, c!("reset"));
             println!(
                 "       {}file: {}{}",
                 c!("dim"),
@@ -196,6 +197,7 @@ pub fn print_summarized(sessions: &[Session]) {
         println!("{}No sessions found.{}", c!("dim"), c!("reset"));
         return;
     }
+    let counts = copy_counts(sessions);
     let mut by_day: BTreeMap<&str, Vec<&Session>> = BTreeMap::new();
     for s in sessions {
         by_day.entry(&s.date).or_default().push(s);
@@ -225,7 +227,7 @@ pub fn print_summarized(sessions: &[Session]) {
                 src_tag(&s.source),
                 id_chip(s),
                 dir_label(&s.project),
-                copies_label(sessions, s),
+                copies_label(&counts, s),
                 labeled("BRANCH", &s.branch)
             );
             print_title_line(&title);
@@ -396,7 +398,7 @@ pub fn print_inspect(info: &InspectInfo) {
     } else {
         abbreviate_home(&info.project)
     };
-    println!("  {}id: {}{}", c!("dim"), display_full_id(&info.source, &info.session_id), c!("reset"));
+    println!("  {}id: {}{}", c!("dim"), info.session_id, c!("reset"));
     println!(
         "  {}date: {}  cwd: {}  branch: {}{}",
         c!("dim"),
@@ -508,7 +510,7 @@ pub fn print_transcript(messages: &[Message], session: &Session, show_tools: boo
     println!(
         "  {}id: {}  date: {}  branch: {}  cwd: {}{}",
         c!("dim"),
-        display_full_id(&session.source, &session.id),
+        session.id,
         session.date,
         if session.branch.is_empty() {
             "-"
@@ -569,59 +571,26 @@ pub fn print_plain(messages: &[Message]) {
 
 /// IDE Composer chats have no CLI resume. Tell the user how to open it.
 pub fn cursor_ide_resume_hint(session: &Session) -> String {
-    let dir = if session.project.is_empty() {
-        "(unknown directory)".into()
-    } else {
-        abbreviate_home(&session.project)
-    };
     let title = title_of(&session.summary, &session.first_prompt, 100);
+    if session.project.is_empty() {
+        return format!(
+            "You need to use the Cursor IDE UI to find this session.\n\
+             This chat has no recorded workspace directory.\n\
+             IDE chats cannot be resumed from the CLI.\n\
+             \n\
+             Title: {title}\n\
+             Look for it in the Cursor sidebar after opening a related project.\n"
+        );
+    }
+    let dir = abbreviate_home(&session.project);
     format!(
         "You need to use the Cursor IDE UI in the directory {dir} to find this session.\n\
          IDE chats cannot be resumed from the CLI.\n\
          \n\
          Title: {title}\n\
-         Open that folder in Cursor and look for the chat in the sidebar.\n"
-    )
-}
-
-pub fn is_ide_placeholder_id(sid: &str) -> bool {
-    let s = sid.trim();
-    s == "00000000" || s == "000000"
-}
-
-/// `resume 00000000` — the list placeholder is shared by every IDE chat.
-pub fn cursor_ide_placeholder_resume_hint(ide_sessions: &[Session]) -> String {
-    if ide_sessions.len() == 1 {
-        return cursor_ide_resume_hint(&ide_sessions[0]);
-    }
-    let mut dirs: Vec<String> = ide_sessions
-        .iter()
-        .map(|s| {
-            if s.project.is_empty() {
-                "(unknown directory)".into()
-            } else {
-                abbreviate_home(&s.project)
-            }
-        })
-        .collect();
-    dirs.sort();
-    dirs.dedup();
-    if dirs.is_empty() {
-        return "You need to use the Cursor IDE UI in the original workspace directory to find this session.\n\
-                IDE chats (shown as 00000000) cannot be resumed from the CLI.\n"
-            .into();
-    }
-    let listed = dirs
-        .iter()
-        .map(|d| format!("  {d}"))
-        .collect::<Vec<_>>()
-        .join("\n");
-    format!(
-        "You need to use the Cursor IDE UI in the original directory to find this session.\n\
-         IDE chats (shown as 00000000) cannot be resumed from the CLI.\n\
-         \n\
-         Open Cursor in one of these folders and look for the chat in the sidebar:\n\
-         {listed}\n"
+         Session ID: {}\n\
+         Open that folder in Cursor and look for the chat in the sidebar.\n",
+        session.id
     )
 }
 
@@ -653,7 +622,7 @@ pub fn export_transcript(messages: &[Message], session: &Session, out_path: Opti
     ));
     lines.push(format!(
         "- **Session ID:** {}\n\n---\n",
-        display_full_id(&session.source, &session.id)
+        session.id
     ));
     for msg in messages {
         let role = if msg.role == "user" {
@@ -696,9 +665,9 @@ mod tests {
     use crate::session::Session;
 
     #[test]
-    fn ide_resume_hint_includes_directory_not_composer_id() {
+    fn ide_resume_hint_includes_directory() {
         let session = Session {
-            source: "cursor".into(),
+            source: "cursor-ide".into(),
             id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".into(),
             summary: "git branch analysis".into(),
             first_prompt: String::new(),
@@ -712,7 +681,7 @@ mod tests {
             is_sidechain: false,
         };
         let hint = cursor_ide_resume_hint(&session);
-        assert!(!hint.contains("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"));
+        assert!(hint.contains("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"));
         assert!(hint.contains("Cursor IDE UI"));
         assert!(hint.contains("/home/alice/src/myapp") || hint.contains("myapp"));
         assert!(hint.contains("git branch analysis"));
@@ -720,41 +689,24 @@ mod tests {
     }
 
     #[test]
-    fn placeholder_id_matches_display_chip() {
-        assert!(super::is_ide_placeholder_id("00000000"));
-        assert!(super::is_ide_placeholder_id("000000"));
-        assert!(super::is_ide_placeholder_id("  00000000  "));
-        assert!(!super::is_ide_placeholder_id("aaaaaaaa"));
-    }
-
-    #[test]
-    fn placeholder_resume_hint_lists_directories() {
-        let a = Session {
-            source: "cursor".into(),
+    fn ide_resume_hint_omits_unknown_directory() {
+        let session = Session {
+            source: "cursor-ide".into(),
             id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".into(),
-            summary: "fix the widget layout".into(),
+            summary: "untitled".into(),
             first_prompt: String::new(),
             created: String::new(),
             modified: String::new(),
-            date: "2026-08-01".into(),
-            messages: 0,
+            date: "2026-08-26".into(),
+            messages: 1,
             branch: String::new(),
-            project: "/home/alice/src/myapp".into(),
+            project: String::new(),
             file: String::new(),
             is_sidechain: false,
         };
-        let mut b = a.clone();
-        b.project = "/home/alice/src/other".into();
-        let hint = super::cursor_ide_placeholder_resume_hint(&[a, b]);
-        assert!(hint.contains("Cursor IDE UI"));
-        assert!(hint.contains("myapp"));
-        assert!(hint.contains("other"));
-    }
-
-    #[test]
-    fn ide_display_id_is_placeholder() {
-        assert_eq!(super::display_id("cursor", "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"), "00000000");
-        assert_eq!(super::display_id("cursor-agent", "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"), "aaaaaaaa");
+        let hint = cursor_ide_resume_hint(&session);
+        assert!(!hint.contains("(unknown directory)"));
+        assert!(hint.contains("no recorded workspace"));
     }
 
     #[test]

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,7 +1,7 @@
 use crate::inspect::InspectInfo;
 use crate::parser::{clean_prompt, display_title, snippet_around_match};
 use crate::search::{IndexResult, SearchResult};
-use crate::session::{Message, Session};
+use crate::session::{self, Message, Session};
 use std::collections::BTreeMap;
 use std::sync::LazyLock;
 
@@ -36,18 +36,91 @@ macro_rules! c {
 }
 
 fn src_tag(source: &str) -> String {
-    match source {
-        "claude" => format!("{}{} CC {}", c!("bg_cyan"), c!("bold"), c!("reset")),
-        "codex" => format!("{}{} CX {}", c!("bg_magenta"), c!("bold"), c!("reset")),
-        _ => format!("{}{} CR {}", c!("bg_blue"), c!("bold"), c!("reset")),
+    let label = match source {
+        "claude" => "claude",
+        "codex" => "codex",
+        "cursor" => "cursor",
+        _ => "cursor-agent",
+    };
+    let color = match source {
+        "claude" => "bg_cyan",
+        "codex" => "bg_magenta",
+        "cursor" => "bg_blue",
+        _ => "bg_blue",
+    };
+    format!("{}{} {:<12} {}", c!(color), c!("bold"), label, c!("reset"))
+}
+
+fn labeled(label: &str, value: &str) -> String {
+    if value.is_empty() {
+        String::new()
+    } else {
+        format!(" {}{}:{} {}", c!("dim"), label, c!("reset"), value)
     }
 }
 
-/// Dim 8-char session-id chip. Every prefix resolves via `inspect`/`view`/
-/// `resume`/`find`, so each row carries its own address.
-fn id_chip(id: &str) -> String {
-    let short: String = id.chars().take(8).collect();
+/// Replace the user home directory with `~` for display (`/home/you/x` or
+/// `/Users/you/x` → `~/x`). Uses `$HOME` (Linux/macOS) or `%USERPROFILE%`.
+pub fn abbreviate_home(path: &str) -> String {
+    let home = session::user_home();
+    abbreviate_home_with(path, home.as_deref().and_then(|p| p.to_str()))
+}
+
+fn abbreviate_home_with(path: &str, home: Option<&str>) -> String {
+    let Some(home) = home.filter(|h| !h.is_empty()) else {
+        return path.to_string();
+    };
+    let home = home.trim_end_matches(['/', '\\']);
+    if path == home || path.trim_end_matches(['/', '\\']) == home {
+        return "~".into();
+    }
+    for sep in ['/', '\\'] {
+        let prefix = format!("{home}{sep}");
+        if let Some(rest) = path.strip_prefix(&prefix) {
+            return format!("~/{}", rest.replace('\\', "/"));
+        }
+    }
+    path.to_string()
+}
+
+fn dir_label(project: &str) -> String {
+    labeled("DIR", &abbreviate_home(project))
+}
+
+fn copies_label(sessions: &[Session], s: &Session) -> String {
+    let n = session::copy_count(sessions, s);
+    if n > 1 {
+        labeled("COPIES", &n.to_string())
+    } else {
+        String::new()
+    }
+}
+
+fn print_title_line(title: &str) {
+    println!("        {}{}{}", c!("bold"), title, c!("reset"));
+}
+
+/// Dim 8-char session-id chip. IDE (`cursor`) chats aren't CLI-resumable,
+/// so they show a placeholder instead of the composer UUID.
+fn id_chip(session: &Session) -> String {
+    let short = display_id(&session.source, &session.id);
     format!("{}{:8}{}", c!("dim"), short, c!("reset"))
+}
+
+fn display_id(source: &str, id: &str) -> String {
+    if source == "cursor" {
+        "00000000".into()
+    } else {
+        id.chars().take(8).collect()
+    }
+}
+
+fn display_full_id(source: &str, id: &str) -> String {
+    if source == "cursor" {
+        "00000000".into()
+    } else {
+        id.to_string()
+    }
 }
 
 /// Best one-line title for a session: summary, else cleaned first prompt.
@@ -76,12 +149,8 @@ pub fn print_list(sessions: &[Session], verbose: bool) {
     );
     for (i, s) in sessions.iter().enumerate() {
         let tag = src_tag(&s.source);
-        let title = title_of(&s.summary, &s.first_prompt, 72);
-        let branch = if s.branch.is_empty() {
-            String::new()
-        } else {
-            format!(" {}({}){}", c!("magenta"), s.branch, c!("reset"))
-        };
+        let title = title_of(&s.summary, &s.first_prompt, 100);
+        let branch = labeled("BRANCH", &s.branch);
         let sidechain = if s.is_sidechain {
             format!(" {}[subagent]{}", c!("dim"), c!("reset"))
         } else {
@@ -93,7 +162,7 @@ pub fn print_list(sessions: &[Session], verbose: bool) {
             String::new()
         };
         println!(
-            "  {}{:3}.{} {} {}{}{}  {}  {}{}{}{}{}{}",
+            "  {}{:3}.{} {} {}{}{}  {}{}{}{}{}{}",
             c!("dim"),
             i + 1,
             c!("reset"),
@@ -101,17 +170,22 @@ pub fn print_list(sessions: &[Session], verbose: bool) {
             c!("cyan"),
             s.date,
             c!("reset"),
-            id_chip(&s.id),
-            c!("bold"),
-            title,
-            c!("reset"),
+            id_chip(s),
+            dir_label(&s.project),
+            copies_label(sessions, s),
             sidechain,
             branch,
             msgs
         );
+        print_title_line(&title);
         if verbose {
-            println!("       {}id: {}{}", c!("dim"), s.id, c!("reset"));
-            println!("       {}file: {}{}", c!("dim"), s.file, c!("reset"));
+            println!("       {}id: {}{}", c!("dim"), display_full_id(&s.source, &s.id), c!("reset"));
+            println!(
+                "       {}file: {}{}",
+                c!("dim"),
+                abbreviate_home(&s.file),
+                c!("reset")
+            );
         }
     }
     println!();
@@ -145,19 +219,16 @@ pub fn print_summarized(sessions: &[Session]) {
             c!("reset")
         );
         for s in ds {
-            let title = title_of(&s.summary, &s.first_prompt, 72);
-            let branch = if s.branch.is_empty() {
-                String::new()
-            } else {
-                format!(" {}({}){}", c!("magenta"), s.branch, c!("reset"))
-            };
+            let title = title_of(&s.summary, &s.first_prompt, 100);
             println!(
-                "    {} {}  {}{}",
+                "    {} {}{}{}{}",
                 src_tag(&s.source),
-                id_chip(&s.id),
-                title,
-                branch
+                id_chip(s),
+                dir_label(&s.project),
+                copies_label(sessions, s),
+                labeled("BRANCH", &s.branch)
             );
+            print_title_line(&title);
         }
         println!();
     }
@@ -180,15 +251,9 @@ pub fn print_index_results(results: &[IndexResult], query: &str) {
     for (i, r) in results.iter().enumerate() {
         let tag = src_tag(&r.session.source);
         let score = format!("{}★ {:.1}{}", c!("yellow"), r.score, c!("reset"));
-        let field = format!("{} [{}]{}", c!("dim"), r.matched_field, c!("reset"));
-        let title = title_of(&r.session.summary, &r.display, 72);
-        let branch = if r.session.branch.is_empty() {
-            String::new()
-        } else {
-            format!(" {}({}){}", c!("magenta"), r.session.branch, c!("reset"))
-        };
+        let title = title_of(&r.session.summary, &r.display, 100);
         println!(
-            "  {}{:3}.{} {} {}{}{} {} {}{} {}{}{}{}",
+            "  {}{:3}.{} {} {}{}{} {} {}{}{}",
             c!("dim"),
             i + 1,
             c!("reset"),
@@ -196,14 +261,12 @@ pub fn print_index_results(results: &[IndexResult], query: &str) {
             c!("cyan"),
             r.session.date,
             c!("reset"),
-            id_chip(&r.session.id),
+            id_chip(&r.session),
             score,
-            field,
-            c!("bold"),
-            title,
-            c!("reset"),
-            branch
+            dir_label(&r.session.project),
+            labeled("INDEX_FIELD", &r.matched_field)
         );
+        print_title_line(&title);
     }
     println!();
 }
@@ -233,9 +296,9 @@ pub fn print_search_results(results: &[SearchResult], query: &str) {
         } else {
             format!("{}Assistant{}", c!("blue"), c!("reset"))
         };
-        let title = title_of(&r.session.summary, &r.session.first_prompt, 72);
+        let title = title_of(&r.session.summary, &r.session.first_prompt, 100);
         println!(
-            "  {}{:3}.{} {} {}{}{} {} {}  {}{}{}",
+            "  {}{:3}.{} {} {}{}{} {} {}{}",
             c!("dim"),
             i + 1,
             c!("reset"),
@@ -243,14 +306,13 @@ pub fn print_search_results(results: &[SearchResult], query: &str) {
             c!("cyan"),
             r.session.date,
             c!("reset"),
-            id_chip(&r.session.id),
+            id_chip(&r.session),
             score,
-            c!("bold"),
-            title,
-            c!("reset")
+            dir_label(&r.session.project)
         );
+        print_title_line(&title);
         let snippet = snippet_around_match(&r.message.content, query, 200);
-        println!("       {}: {}", role_str, snippet);
+        println!("        {}: {}", role_str, snippet);
         if !r.message.tool_uses.is_empty() {
             let tools: String = r
                 .message
@@ -268,7 +330,7 @@ pub fn print_search_results(results: &[SearchResult], query: &str) {
                 .files_referenced
                 .iter()
                 .take(3)
-                .cloned()
+                .map(|f| abbreviate_home(f))
                 .collect::<Vec<_>>()
                 .join(", ");
             println!("       {}files: {}{}", c!("dim"), files, c!("reset"));
@@ -329,12 +391,17 @@ pub fn print_inspect(info: &InspectInfo) {
     };
     println!("\n{}", "─".repeat(80));
     println!("  {}  {}{}{}", tag, c!("bold"), summary, c!("reset"));
-    println!("  {}id: {}{}", c!("dim"), info.session_id, c!("reset"));
+    let cwd = if info.project.is_empty() {
+        "-".to_string()
+    } else {
+        abbreviate_home(&info.project)
+    };
+    println!("  {}id: {}{}", c!("dim"), display_full_id(&info.source, &info.session_id), c!("reset"));
     println!(
-        "  {}date: {}  project: {}  branch: {}{}",
+        "  {}date: {}  cwd: {}  branch: {}{}",
         c!("dim"),
         info.date,
-        info.project,
+        cwd,
         if info.branch.is_empty() {
             "-"
         } else {
@@ -380,7 +447,7 @@ pub fn print_inspect(info: &InspectInfo) {
             c!("reset")
         );
         for f in &info.files_modified {
-            println!("    • {f}");
+            println!("    • {}", abbreviate_home(f));
         }
         println!();
     }
@@ -433,21 +500,22 @@ pub fn print_transcript(messages: &[Message], session: &Session, show_tools: boo
     };
     println!("\n{}", "─".repeat(80));
     println!("  {}  {}{}{}", tag, c!("bold"), summary, c!("reset"));
+    let cwd = if session.project.is_empty() {
+        "-".to_string()
+    } else {
+        abbreviate_home(&session.project)
+    };
     println!(
-        "  {}id: {}  date: {}  branch: {}  project: {}{}",
+        "  {}id: {}  date: {}  branch: {}  cwd: {}{}",
         c!("dim"),
-        session.id,
+        display_full_id(&session.source, &session.id),
         session.date,
         if session.branch.is_empty() {
             "-"
         } else {
             &session.branch
         },
-        if session.project.is_empty() {
-            "-"
-        } else {
-            &session.project
-        },
+        cwd,
         c!("reset")
     );
     println!("{}\n", "─".repeat(80));
@@ -499,6 +567,64 @@ pub fn print_plain(messages: &[Message]) {
     }
 }
 
+/// IDE Composer chats have no CLI resume. Tell the user how to open it.
+pub fn cursor_ide_resume_hint(session: &Session) -> String {
+    let dir = if session.project.is_empty() {
+        "(unknown directory)".into()
+    } else {
+        abbreviate_home(&session.project)
+    };
+    let title = title_of(&session.summary, &session.first_prompt, 100);
+    format!(
+        "You need to use the Cursor IDE UI in the directory {dir} to find this session.\n\
+         IDE chats cannot be resumed from the CLI.\n\
+         \n\
+         Title: {title}\n\
+         Open that folder in Cursor and look for the chat in the sidebar.\n"
+    )
+}
+
+pub fn is_ide_placeholder_id(sid: &str) -> bool {
+    let s = sid.trim();
+    s == "00000000" || s == "000000"
+}
+
+/// `resume 00000000` — the list placeholder is shared by every IDE chat.
+pub fn cursor_ide_placeholder_resume_hint(ide_sessions: &[Session]) -> String {
+    if ide_sessions.len() == 1 {
+        return cursor_ide_resume_hint(&ide_sessions[0]);
+    }
+    let mut dirs: Vec<String> = ide_sessions
+        .iter()
+        .map(|s| {
+            if s.project.is_empty() {
+                "(unknown directory)".into()
+            } else {
+                abbreviate_home(&s.project)
+            }
+        })
+        .collect();
+    dirs.sort();
+    dirs.dedup();
+    if dirs.is_empty() {
+        return "You need to use the Cursor IDE UI in the original workspace directory to find this session.\n\
+                IDE chats (shown as 00000000) cannot be resumed from the CLI.\n"
+            .into();
+    }
+    let listed = dirs
+        .iter()
+        .map(|d| format!("  {d}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "You need to use the Cursor IDE UI in the original directory to find this session.\n\
+         IDE chats (shown as 00000000) cannot be resumed from the CLI.\n\
+         \n\
+         Open Cursor in one of these folders and look for the chat in the sidebar:\n\
+         {listed}\n"
+    )
+}
+
 pub fn export_transcript(messages: &[Message], session: &Session, out_path: Option<&str>) -> bool {
     let summary = if session.summary.is_empty() {
         "(no summary)"
@@ -518,14 +644,17 @@ pub fn export_transcript(messages: &[Message], session: &Session, out_path: Opti
         }
     ));
     lines.push(format!(
-        "- **Project:** {}",
+        "- **Directory:** {}",
         if session.project.is_empty() {
             "-"
         } else {
             &session.project
         }
     ));
-    lines.push(format!("- **Session ID:** {}\n\n---\n", session.id));
+    lines.push(format!(
+        "- **Session ID:** {}\n\n---\n",
+        display_full_id(&session.source, &session.id)
+    ));
     for msg in messages {
         let role = if msg.role == "user" {
             "You"
@@ -557,5 +686,116 @@ pub fn export_transcript(messages: &[Message], session: &Session, out_path: Opti
             eprintln!("Error writing {path}: {e}");
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::abbreviate_home_with;
+    use super::cursor_ide_resume_hint;
+    use crate::session::Session;
+
+    #[test]
+    fn ide_resume_hint_includes_directory_not_composer_id() {
+        let session = Session {
+            source: "cursor".into(),
+            id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".into(),
+            summary: "git branch analysis".into(),
+            first_prompt: String::new(),
+            created: String::new(),
+            modified: String::new(),
+            date: "2026-08-26".into(),
+            messages: 0,
+            branch: String::new(),
+            project: "/home/alice/src/myapp".into(),
+            file: String::new(),
+            is_sidechain: false,
+        };
+        let hint = cursor_ide_resume_hint(&session);
+        assert!(!hint.contains("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"));
+        assert!(hint.contains("Cursor IDE UI"));
+        assert!(hint.contains("/home/alice/src/myapp") || hint.contains("myapp"));
+        assert!(hint.contains("git branch analysis"));
+        assert!(hint.contains("sidebar"));
+    }
+
+    #[test]
+    fn placeholder_id_matches_display_chip() {
+        assert!(super::is_ide_placeholder_id("00000000"));
+        assert!(super::is_ide_placeholder_id("000000"));
+        assert!(super::is_ide_placeholder_id("  00000000  "));
+        assert!(!super::is_ide_placeholder_id("aaaaaaaa"));
+    }
+
+    #[test]
+    fn placeholder_resume_hint_lists_directories() {
+        let a = Session {
+            source: "cursor".into(),
+            id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".into(),
+            summary: "fix the widget layout".into(),
+            first_prompt: String::new(),
+            created: String::new(),
+            modified: String::new(),
+            date: "2026-08-01".into(),
+            messages: 0,
+            branch: String::new(),
+            project: "/home/alice/src/myapp".into(),
+            file: String::new(),
+            is_sidechain: false,
+        };
+        let mut b = a.clone();
+        b.project = "/home/alice/src/other".into();
+        let hint = super::cursor_ide_placeholder_resume_hint(&[a, b]);
+        assert!(hint.contains("Cursor IDE UI"));
+        assert!(hint.contains("myapp"));
+        assert!(hint.contains("other"));
+    }
+
+    #[test]
+    fn ide_display_id_is_placeholder() {
+        assert_eq!(super::display_id("cursor", "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"), "00000000");
+        assert_eq!(super::display_id("cursor-agent", "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"), "aaaaaaaa");
+    }
+
+    #[test]
+    fn abbreviates_linux_home() {
+        assert_eq!(
+            abbreviate_home_with("/home/alice/src/app", Some("/home/alice")),
+            "~/src/app"
+        );
+    }
+
+    #[test]
+    fn abbreviates_macos_home() {
+        assert_eq!(
+            abbreviate_home_with("/Users/alex/src/app", Some("/Users/alex")),
+            "~/src/app"
+        );
+    }
+
+    #[test]
+    fn abbreviates_home_itself() {
+        assert_eq!(abbreviate_home_with("/home/alice", Some("/home/alice")), "~");
+        assert_eq!(abbreviate_home_with("/home/alice/", Some("/home/alice")), "~");
+    }
+
+    #[test]
+    fn leaves_unrelated_paths_alone() {
+        assert_eq!(
+            abbreviate_home_with("/opt/tools", Some("/home/alice")),
+            "/opt/tools"
+        );
+        assert_eq!(
+            abbreviate_home_with("/home/alice-other/x", Some("/home/alice")),
+            "/home/alice-other/x"
+        );
+    }
+
+    #[test]
+    fn abbreviates_windows_home() {
+        assert_eq!(
+            abbreviate_home_with(r"C:\Users\alex\proj", Some(r"C:\Users\alex")),
+            "~/proj"
+        );
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -359,6 +359,7 @@ pub fn print_search_results_json(results: &[SearchResult], query: &str) {
             serde_json::json!({
                 "session_id": r.session.id,
                 "source": r.session.source,
+                "also_ide": r.session.also_ide,
                 "date": r.session.date,
                 "summary": r.session.summary,
                 "project": r.session.project,
@@ -381,6 +382,7 @@ pub fn print_index_results_json(results: &[IndexResult], query: &str) {
             serde_json::json!({
                 "session_id": r.session.id,
                 "source": r.session.source,
+                "also_ide": r.session.also_ide,
                 "date": r.session.date,
                 "summary": r.session.summary,
                 "project": r.session.project,

--- a/src/display.rs
+++ b/src/display.rs
@@ -92,7 +92,10 @@ fn dir_label(project: &str) -> String {
     labeled("DIR", &abbreviate_home(project))
 }
 
-fn copies_label(counts: &std::collections::HashMap<(String, String), usize>, s: &Session) -> String {
+fn copies_label(
+    counts: &std::collections::HashMap<(String, String), usize>,
+    s: &Session,
+) -> String {
     let n = counts
         .get(&(s.source.clone(), s.id.to_ascii_lowercase()))
         .copied()
@@ -628,10 +631,7 @@ pub fn export_transcript(messages: &[Message], session: &Session, out_path: Opti
             &session.project
         }
     ));
-    lines.push(format!(
-        "- **Session ID:** {}\n\n---\n",
-        session.id
-    ));
+    lines.push(format!("- **Session ID:** {}\n\n---\n", session.id));
     for msg in messages {
         let role = if msg.role == "user" {
             "You"
@@ -776,8 +776,14 @@ mod tests {
 
     #[test]
     fn abbreviates_home_itself() {
-        assert_eq!(abbreviate_home_with("/home/alice", Some("/home/alice")), "~");
-        assert_eq!(abbreviate_home_with("/home/alice/", Some("/home/alice")), "~");
+        assert_eq!(
+            abbreviate_home_with("/home/alice", Some("/home/alice")),
+            "~"
+        );
+        assert_eq!(
+            abbreviate_home_with("/home/alice/", Some("/home/alice")),
+            "~"
+        );
     }
 
     #[test]

--- a/src/display.rs
+++ b/src/display.rs
@@ -36,17 +36,21 @@ macro_rules! c {
     };
 }
 
-fn src_tag(source: &str) -> String {
+fn src_tag(source: &str, also_ide: bool) -> String {
+    // IDE Agent chats write SQLite *and* an agent-transcripts jsonl with the
+    // same composer id. Prefer the IDE label — that's the UI the user used.
     let label = match source {
         "claude" => "claude",
         "codex" => "codex",
         "cursor-ide" => "cursor-ide",
-        _ => "cursor",
+        "cursor" if also_ide => "cursor-ide",
+        _ => "cursor-agent",
     };
     let color = match source {
         "claude" => "bg_cyan",
         "codex" => "bg_magenta",
         "cursor-ide" => "bg_yellow",
+        "cursor" if also_ide => "bg_yellow",
         _ => "bg_blue",
     };
     format!("{}{} {:<12} {}", c!(color), c!("bold"), label, c!("reset"))
@@ -116,9 +120,13 @@ fn print_title_line(title: &str) {
     println!("        {}{}{}", c!("bold"), title, c!("reset"));
 }
 
-/// Dim 8-char session-id chip. Every prefix resolves via inspect/view/
-/// export/resume/find.
+/// Dim 8-char session-id chip. Claude/Codex/Agent-CLI prefixes resolve via
+/// inspect/view/export/resume/find. Rows tagged `cursor-ide` omit the prefix
+/// (not shown in the Cursor sidebar). `list -v` still prints the full id.
 fn id_chip(session: &Session) -> String {
+    if session.is_ide_ui() {
+        return format!("{}--------{}", c!("dim"), c!("reset"));
+    }
     let short: String = session.id.chars().take(8).collect();
     format!("{}{:8}{}", c!("dim"), short, c!("reset"))
 }
@@ -149,7 +157,7 @@ pub fn print_list(sessions: &[Session], verbose: bool) {
     );
     let counts = copy_counts(sessions);
     for (i, s) in sessions.iter().enumerate() {
-        let tag = src_tag(&s.source);
+        let tag = src_tag(&s.source, s.also_ide);
         let title = title_of(&s.summary, &s.first_prompt, 100);
         let branch = labeled("BRANCH", &s.branch);
         let sidechain = if s.is_sidechain {
@@ -224,7 +232,7 @@ pub fn print_summarized(sessions: &[Session]) {
             let title = title_of(&s.summary, &s.first_prompt, 100);
             println!(
                 "    {} {}{}{}{}",
-                src_tag(&s.source),
+                src_tag(&s.source, s.also_ide),
                 id_chip(s),
                 dir_label(&s.project),
                 copies_label(&counts, s),
@@ -251,7 +259,7 @@ pub fn print_index_results(results: &[IndexResult], query: &str) {
         c!("reset")
     );
     for (i, r) in results.iter().enumerate() {
-        let tag = src_tag(&r.session.source);
+        let tag = src_tag(&r.session.source, r.session.also_ide);
         let score = format!("{}★ {:.1}{}", c!("yellow"), r.score, c!("reset"));
         let title = title_of(&r.session.summary, &r.display, 100);
         println!(
@@ -286,7 +294,7 @@ pub fn print_search_results(results: &[SearchResult], query: &str) {
         c!("reset")
     );
     for (i, r) in results.iter().enumerate() {
-        let tag = src_tag(&r.session.source);
+        let tag = src_tag(&r.session.source, r.session.also_ide);
         let score = format!(
             "{}★ {:.1}{}",
             c!("yellow"),
@@ -384,7 +392,7 @@ pub fn print_index_results_json(results: &[IndexResult], query: &str) {
 }
 
 pub fn print_inspect(info: &InspectInfo) {
-    let tag = src_tag(&info.source);
+    let tag = src_tag(&info.source, info.also_ide);
     let cleaned = display_title(&info.summary, 120);
     let summary = if cleaned.is_empty() {
         "(no summary)"
@@ -493,7 +501,7 @@ pub fn print_inspect(info: &InspectInfo) {
 }
 
 pub fn print_transcript(messages: &[Message], session: &Session, show_tools: bool) {
-    let tag = src_tag(&session.source);
+    let tag = src_tag(&session.source, session.also_ide);
     let cleaned = title_of(&session.summary, &session.first_prompt, 120);
     let summary = if cleaned == "(untitled)" {
         "(no summary)"
@@ -679,6 +687,7 @@ mod tests {
             project: "/home/alice/src/myapp".into(),
             file: String::new(),
             is_sidechain: false,
+            also_ide: false,
         };
         let hint = cursor_ide_resume_hint(&session);
         assert!(hint.contains("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"));
@@ -703,10 +712,50 @@ mod tests {
             project: String::new(),
             file: String::new(),
             is_sidechain: false,
+            also_ide: false,
         };
         let hint = cursor_ide_resume_hint(&session);
         assert!(!hint.contains("(unknown directory)"));
         assert!(hint.contains("no recorded workspace"));
+    }
+
+    #[test]
+    fn src_tag_labels_agent_as_cursor_agent() {
+        assert!(super::src_tag("cursor", false).contains("cursor-agent"));
+        assert!(super::src_tag("cursor-ide", false).contains("cursor-ide"));
+        assert!(super::src_tag("cursor", true).contains("cursor-ide"));
+        assert!(!super::src_tag("cursor", false).contains("cursor-ide"));
+    }
+
+    #[test]
+    fn id_chip_hides_ide_composer_prefix() {
+        let ide = Session {
+            source: "cursor-ide".into(),
+            id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".into(),
+            summary: "sidebar title".into(),
+            first_prompt: String::new(),
+            created: String::new(),
+            modified: String::new(),
+            date: "2026-08-26".into(),
+            messages: 2,
+            branch: String::new(),
+            project: "/tmp".into(),
+            file: String::new(),
+            is_sidechain: false,
+            also_ide: false,
+        };
+        let mut agent = Session {
+            source: "cursor".into(),
+            id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".into(),
+            ..ide.clone()
+        };
+        assert!(super::id_chip(&ide).contains("--------"));
+        assert!(!super::id_chip(&ide).contains("aaaaaaaa"));
+        assert!(super::id_chip(&agent).contains("aaaaaaaa"));
+        agent.also_ide = true;
+        assert!(super::src_tag("cursor", true).contains("cursor-ide"));
+        assert!(super::id_chip(&agent).contains("--------"));
+        assert!(!super::id_chip(&agent).contains("aaaaaaaa"));
     }
 
     #[test]

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -17,6 +17,7 @@ pub struct InspectInfo {
     pub decisions: Vec<String>,
     pub errors: Vec<String>,
     pub source: String,
+    pub also_ide: bool,
     pub model: String,
     pub total_tokens: u64,
 }
@@ -203,6 +204,7 @@ pub fn inspect_session(session: &Session) -> Option<InspectInfo> {
         decisions,
         errors: errors_seen,
         source: session.source.clone(),
+        also_ide: session.also_ide,
         model: meta.model.unwrap_or_default(),
         total_tokens: meta.total_tokens,
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cursor_ide;
 pub mod dates;
 pub mod display;
 pub mod inspect;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,13 +12,15 @@ use clap::{Parser, Subcommand};
     name = "chat-history",
     about = "Search Claude Code + Cursor + Codex conversation history",
     long_about = "Search Claude Code + Cursor + Codex conversation history.\n\n\
-        With no command, lists sessions newest first; every row shows a short\n\
-        session ID usable with inspect/view/export/resume/find.",
+        With no command, lists sessions newest first. Claude, Codex, and\n\
+        cursor-agent rows show a short ID for inspect/view/export/resume/find.\n\
+        cursor-ide rows hide that ID and cannot be resumed from the CLI.",
     version,
     after_help = "EXAMPLES:\n  \
         chat-history                                  list sessions, newest first\n  \
         chat-history --from yesterday --to yesterday  sessions from a specific day\n  \
         chat-history search \"auth error\" --deep --json\n  \
+        chat-history --source cursor-ide              IDE sidebar chats only\n  \
         chat-history inspect 6b1094cd                 summarize by short ID\n  \
         chat-history view 6b1094cd --plain | less\n\n\
         EXIT CODES:\n  \
@@ -129,7 +131,7 @@ enum Commands {
         #[arg(short = 'o', long)]
         output: Option<String>,
     },
-    /// Resume a Claude Code, Cursor Agent, or Codex session in its original tool
+    /// Resume Claude Code, Cursor Agent CLI, or Codex (not Cursor IDE sidebar chats)
     Resume {
         /// Session ID or unique prefix
         session_id: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use chat_history::dates::parse_human_date;
 use chat_history::session::{
-    self, SessionLookup, filter_sessions, load_all_sessions, lookup_session, parse_session,
+    self, ResumeAction, SessionLookup, filter_sessions, load_sessions, lookup_session, parse_session,
     session_copies,
 };
 use chat_history::skill_install::{ensure_skills, install_skill};
@@ -41,7 +41,7 @@ struct Cli {
     #[arg(
         long,
         global = true,
-        value_parser = ["claude", "cursor", "cursor-agent", "codex"],
+        value_parser = ["claude", "cursor", "cursor-agent", "cursor-ide", "codex"],
         help = "Filter by source"
     )]
     source: Option<String>,
@@ -164,7 +164,7 @@ fn resolve_session_or_exit<'a>(
             let copies = session_copies(sessions, s);
             if copies.len() > 1 {
                 eprintln!(
-                    "Note: session {} is stored in {} Cursor/project folders; using DIR: {}",
+                    "Note: session {} is stored in {} project folders; using DIR: {}",
                     s.id,
                     copies.len(),
                     display::abbreviate_home(&s.project)
@@ -250,7 +250,24 @@ fn main() {
     // upgrades). Never overwrites user-edited skills.
     ensure_skills();
 
-    let mut sessions = load_all_sessions();
+    let id_lookup = matches!(
+        &cli.command,
+        Some(Commands::Inspect {
+            session_id: Some(_),
+            last: false
+        }) | Some(Commands::View {
+            session_id: Some(_),
+            last: false,
+            ..
+        }) | Some(Commands::Export { .. })
+            | Some(Commands::Resume { .. })
+            | Some(Commands::Find { .. })
+    );
+    let mut sessions = if id_lookup {
+        load_sessions(None)
+    } else {
+        load_sessions(cli.source.as_deref())
+    };
     if !cli.sidechains {
         sessions.retain(|s| !s.is_sidechain);
     }
@@ -374,26 +391,29 @@ fn main() {
             }
         }
         Some(Commands::Resume { session_id }) => {
-            if display::is_ide_placeholder_id(&session_id) {
-                let ide: Vec<session::Session> = filtered
-                    .iter()
-                    .filter(|s| s.source == "cursor")
-                    .cloned()
-                    .collect();
-                print!("{}", display::cursor_ide_placeholder_resume_hint(&ide));
-                std::process::exit(1);
-            }
             let session = resolve_session_or_exit(&sessions, &session_id);
-            if session.source == "cursor" {
+            if session.source == "cursor-ide" {
                 print!("{}", display::cursor_ide_resume_hint(session));
                 std::process::exit(1);
             }
-            let Some((bin, args)) = session::resume_command(session) else {
+            let action = match session::resume_command(session) {
+                Some(a) => a,
+                None => {
+                    eprintln!(
+                        "Resume is not supported for {} sessions.",
+                        session.source
+                    );
+                    std::process::exit(1);
+                }
+            };
+            if let ResumeAction::Print { cmdline } = action {
                 eprintln!(
-                    "Resume is not supported for {} sessions.",
-                    session.source
+                    "Not running `cursor agent` (it can install the Agent CLI). Run:\n  {cmdline}"
                 );
                 std::process::exit(1);
+            }
+            let ResumeAction::Exec { bin, args } = action else {
+                unreachable!();
             };
             println!(
                 "Resuming: {}",
@@ -426,10 +446,9 @@ fn main() {
                     }
                 } else {
                     eprintln!(
-                        "Cannot resume: session directory does not exist: {}",
+                        "Warning: session directory {} no longer exists; resuming from the current directory",
                         display::abbreviate_home(&session.project)
                     );
-                    std::process::exit(1);
                 }
             }
             use std::os::unix::process::CommandExt;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use chat_history::dates::parse_human_date;
 use chat_history::session::{
-    self, ResumeAction, SessionLookup, filter_sessions, load_sessions, lookup_session, parse_session,
-    session_copies,
+    self, ResumeAction, SessionLookup, filter_sessions, load_sessions, lookup_session,
+    parse_session, session_copies,
 };
 use chat_history::skill_install::{ensure_skills, install_skill};
 use chat_history::{display, inspect, scoring, search};
@@ -401,10 +401,7 @@ fn main() {
             let action = match session::resume_command(session) {
                 Some(a) => a,
                 None => {
-                    eprintln!(
-                        "Resume is not supported for {} sessions.",
-                        session.source
-                    );
+                    eprintln!("Resume is not supported for {} sessions.", session.source);
                     std::process::exit(1);
                 }
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -392,7 +392,7 @@ fn main() {
         }
         Some(Commands::Resume { session_id }) => {
             let session = resolve_session_or_exit(&sessions, &session_id);
-            if session.source == "cursor-ide" {
+            if session.is_ide_ui() {
                 print!("{}", display::cursor_ide_resume_hint(session));
                 std::process::exit(1);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use chat_history::dates::parse_human_date;
 use chat_history::session::{
     self, SessionLookup, filter_sessions, load_all_sessions, lookup_session, parse_session,
+    session_copies,
 };
 use chat_history::skill_install::{ensure_skills, install_skill};
 use chat_history::{display, inspect, scoring, search};
@@ -40,7 +41,7 @@ struct Cli {
     #[arg(
         long,
         global = true,
-        value_parser = ["claude", "cursor", "codex"],
+        value_parser = ["claude", "cursor", "cursor-agent", "codex"],
         help = "Filter by source"
     )]
     source: Option<String>,
@@ -128,7 +129,7 @@ enum Commands {
         #[arg(short = 'o', long)]
         output: Option<String>,
     },
-    /// Resume a Claude Code or Codex session in its original tool
+    /// Resume a Claude Code, Cursor Agent, or Codex session in its original tool
     Resume {
         /// Session ID or unique prefix
         session_id: String,
@@ -159,11 +160,38 @@ fn resolve_session_or_exit<'a>(
     sid: &str,
 ) -> &'a session::Session {
     match lookup_session(sessions, sid) {
-        SessionLookup::Found(s) => s,
+        SessionLookup::Found(s) => {
+            let copies = session_copies(sessions, s);
+            if copies.len() > 1 {
+                eprintln!(
+                    "Note: session {} is stored in {} Cursor/project folders; using DIR: {}",
+                    s.id,
+                    copies.len(),
+                    display::abbreviate_home(&s.project)
+                );
+                for c in copies {
+                    if c.file == s.file {
+                        continue;
+                    }
+                    eprintln!(
+                        "  also: {}  {}",
+                        display::abbreviate_home(&c.project),
+                        display::abbreviate_home(&c.file)
+                    );
+                }
+            }
+            s
+        }
         SessionLookup::Ambiguous(candidates) => {
             eprintln!("Session ID \"{sid}\" is ambiguous — it matches:");
             for s in &candidates {
-                eprintln!("  {}  {}  {}", s.id, s.date, s.source);
+                eprintln!(
+                    "  {}  {}  {}  DIR: {}",
+                    s.id,
+                    s.date,
+                    s.source,
+                    display::abbreviate_home(&s.project)
+                );
             }
             eprintln!("Use a longer prefix.");
             std::process::exit(2);
@@ -346,11 +374,27 @@ fn main() {
             }
         }
         Some(Commands::Resume { session_id }) => {
-            let session = resolve_session_or_exit(&sessions, &session_id);
-            if session.source != "claude" && session.source != "codex" {
-                eprintln!("Resume is only supported for Claude Code and Codex sessions.");
+            if display::is_ide_placeholder_id(&session_id) {
+                let ide: Vec<session::Session> = filtered
+                    .iter()
+                    .filter(|s| s.source == "cursor")
+                    .cloned()
+                    .collect();
+                print!("{}", display::cursor_ide_placeholder_resume_hint(&ide));
                 std::process::exit(1);
             }
+            let session = resolve_session_or_exit(&sessions, &session_id);
+            if session.source == "cursor" {
+                print!("{}", display::cursor_ide_resume_hint(session));
+                std::process::exit(1);
+            }
+            let Some((bin, args)) = session::resume_command(session) else {
+                eprintln!(
+                    "Resume is not supported for {} sessions.",
+                    session.source
+                );
+                std::process::exit(1);
+            };
             println!(
                 "Resuming: {}",
                 if session.summary.is_empty() {
@@ -359,13 +403,9 @@ fn main() {
                     &session.summary
                 }
             );
-            if !session.project.is_empty() {
-                let project = std::path::Path::new(&session.project);
-                if project.is_dir() {
-                    if let Err(e) = std::env::set_current_dir(project) {
-                        eprintln!("Warning: could not cd to {}: {e}", session.project);
-                    }
-                } else if session.source == "claude" {
+            let workdir = session::resume_working_dir(session);
+            if workdir.is_none() && !session.project.is_empty() {
+                if session.source == "claude" {
                     eprintln!(
                         "Project dir {} no longer exists, copying session to current directory...",
                         session.project
@@ -384,15 +424,22 @@ fn main() {
                             );
                         }
                     }
+                } else {
+                    eprintln!(
+                        "Cannot resume: session directory does not exist: {}",
+                        display::abbreviate_home(&session.project)
+                    );
+                    std::process::exit(1);
                 }
             }
             use std::os::unix::process::CommandExt;
-            let (bin, args) = if session.source == "codex" {
-                ("codex", ["resume", session.id.as_str()])
-            } else {
-                ("claude", ["--resume", session.id.as_str()])
-            };
-            let err = std::process::Command::new(bin).args(args).exec();
+            let mut cmd = std::process::Command::new(&bin);
+            cmd.args(&args);
+            if let Some(dir) = &workdir {
+                println!("cd {}", display::abbreviate_home(&dir.to_string_lossy()));
+                cmd.current_dir(dir);
+            }
+            let err = cmd.exec();
             eprintln!("Failed to exec {bin}: {err}");
             std::process::exit(1);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,9 @@ use clap::{Parser, Subcommand};
     long_about = "Search Claude Code + Cursor + Codex conversation history.\n\n\
         With no command, lists sessions newest first; every row shows a short\n\
         session ID usable with inspect/view/export/find. resume works for\n\
-        claude, codex and cursor-agent rows; cursor-ide rows print how to\n\
-        open the chat in the Cursor sidebar instead.",
+        claude, codex and Cursor Agent CLI chats (ids with a store under\n\
+        ~/.cursor/chats); other Cursor rows print how to open the chat in\n\
+        the Cursor sidebar instead.",
     version,
     after_help = "EXAMPLES:\n  \
         chat-history                                  list sessions, newest first\n  \
@@ -132,7 +133,7 @@ enum Commands {
         #[arg(short = 'o', long)]
         output: Option<String>,
     },
-    /// Resume Claude Code, Cursor Agent CLI, or Codex (not Cursor IDE sidebar chats)
+    /// Resume Claude Code, Codex, or a Cursor Agent CLI chat (IDE chats print how to open them)
     Resume {
         /// Session ID or unique prefix
         session_id: String,
@@ -401,6 +402,14 @@ fn main() {
             }
             let action = match session::resume_command(session) {
                 Some(a) => a,
+                None if session.source == "cursor" => {
+                    eprintln!(
+                        "No Agent CLI chat store for this id under ~/.cursor/chats, so \
+                         `agent --resume` cannot load it (it would start a blank chat)."
+                    );
+                    print!("{}", display::cursor_ide_resume_hint(session));
+                    std::process::exit(1);
+                }
                 None => {
                     eprintln!("Resume is not supported for {} sessions.", session.source);
                     std::process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,9 +12,10 @@ use clap::{Parser, Subcommand};
     name = "chat-history",
     about = "Search Claude Code + Cursor + Codex conversation history",
     long_about = "Search Claude Code + Cursor + Codex conversation history.\n\n\
-        With no command, lists sessions newest first. Claude, Codex, and\n\
-        cursor-agent rows show a short ID for inspect/view/export/resume/find.\n\
-        cursor-ide rows hide that ID and cannot be resumed from the CLI.",
+        With no command, lists sessions newest first; every row shows a short\n\
+        session ID usable with inspect/view/export/find. resume works for\n\
+        claude, codex and cursor-agent rows; cursor-ide rows print how to\n\
+        open the chat in the Cursor sidebar instead.",
     version,
     after_help = "EXAMPLES:\n  \
         chat-history                                  list sessions, newest first\n  \

--- a/src/search.rs
+++ b/src/search.rs
@@ -124,12 +124,10 @@ pub fn index_quality_ok(results: &[IndexResult]) -> bool {
     let Some(best) = results.first() else {
         return false;
     };
-    // Recency damping turns a title hit into 3.0 * 1.5 = 4.5 (under 5.0) for
-    // chats from last month. Those are still the names shown in the IDE.
-    if best.matched_field == "summary" || best.matched_field == "first_prompt" {
-        return true;
+    match best.matched_field.as_str() {
+        "summary" => best.score >= 4.5,
+        _ => best.score >= INDEX_QUALITY_THRESHOLD,
     }
-    best.score >= INDEX_QUALITY_THRESHOLD
 }
 
 fn parse_timeframe_duration(tf: &str) -> chrono::Duration {
@@ -249,17 +247,17 @@ pub fn scored_search(
         .filter(|s| !s.file.is_empty() && std::path::Path::new(&s.file).exists())
         .flat_map(|s| {
             let (mut messages, _) = parse_session(s, false);
-            let title = if !s.summary.is_empty() {
-                s.summary.clone()
-            } else {
-                s.first_prompt.clone()
-            };
+            let title = s.summary.clone();
             if !title.is_empty() && !messages.iter().any(|m| m.content == title) {
                 messages.insert(
                     0,
                     Message {
                         uuid: "index-title".into(),
-                        timestamp: String::new(),
+                        timestamp: if s.modified.is_empty() {
+                            s.created.clone()
+                        } else {
+                            s.modified.clone()
+                        },
                         role: "user".into(),
                         content: title,
                         session_id: s.id.clone(),
@@ -639,6 +637,28 @@ mod tests {
     }
 
     #[test]
+    fn index_quality_old_summary_falls_through() {
+        let results = vec![IndexResult {
+            session: make_session("1", "stale title", "", "proj", "main"),
+            score: 3.0,
+            matched_field: "summary".into(),
+            display: "stale title".into(),
+        }];
+        assert!(!index_quality_ok(&results));
+    }
+
+    #[test]
+    fn index_quality_first_prompt_keeps_five_floor() {
+        let results = vec![IndexResult {
+            session: make_session("1", "", "first prompt text", "proj", "main"),
+            score: 4.5,
+            matched_field: "first_prompt".into(),
+            display: "first prompt text".into(),
+        }];
+        assert!(!index_quality_ok(&results));
+    }
+
+    #[test]
     fn index_quality_ok_empty() {
         assert!(!index_quality_ok(&[]));
     }
@@ -700,7 +720,9 @@ mod tests {
             "main",
         );
         s.file = tmp.path().to_str().unwrap().to_string();
-        let results = scored_search(&[s], "mergeability", "all", 10, None);
+        s.created = "2026-08-20T00:00:00Z".into();
+        s.modified = s.created.clone();
+        let results = scored_search(&[s.clone()], "mergeability", "all", 10, None);
         assert!(
             results
                 .iter()
@@ -710,6 +732,13 @@ mod tests {
                 .iter()
                 .map(|r| r.message.content.clone())
                 .collect::<Vec<_>>()
+        );
+        let recent = scored_search(&[s.clone()], "mergeability", "all", 10, Some("30d"));
+        assert!(
+            recent
+                .iter()
+                .any(|r| r.message.content.contains("mergeability")),
+            "title-only hit should survive a covering timeframe"
         );
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -482,6 +482,7 @@ mod tests {
             project: project.into(),
             file: String::new(),
             is_sidechain: false,
+            also_ide: false,
         }
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -121,9 +121,15 @@ pub fn index_search(sessions: &[Session], query: &str, limit: usize) -> Vec<Inde
 }
 
 pub fn index_quality_ok(results: &[IndexResult]) -> bool {
-    results
-        .first()
-        .is_some_and(|r| r.score >= INDEX_QUALITY_THRESHOLD)
+    let Some(best) = results.first() else {
+        return false;
+    };
+    // Recency damping turns a title hit into 3.0 * 1.5 = 4.5 (under 5.0) for
+    // chats from last month. Those are still the names shown in the IDE.
+    if best.matched_field == "summary" || best.matched_field == "first_prompt" {
+        return true;
+    }
+    best.score >= INDEX_QUALITY_THRESHOLD
 }
 
 fn parse_timeframe_duration(tf: &str) -> chrono::Duration {
@@ -242,7 +248,30 @@ pub fn scored_search(
         .par_iter()
         .filter(|s| !s.file.is_empty() && std::path::Path::new(&s.file).exists())
         .flat_map(|s| {
-            let (messages, _) = parse_session(s, false);
+            let (mut messages, _) = parse_session(s, false);
+            let title = if !s.summary.is_empty() {
+                s.summary.clone()
+            } else {
+                s.first_prompt.clone()
+            };
+            if !title.is_empty() && !messages.iter().any(|m| m.content == title) {
+                messages.insert(
+                    0,
+                    Message {
+                        uuid: "index-title".into(),
+                        timestamp: String::new(),
+                        role: "user".into(),
+                        content: title,
+                        session_id: s.id.clone(),
+                        project_path: s.project.clone(),
+                        tool_uses: Vec::new(),
+                        files_referenced: Vec::new(),
+                        error_patterns: Vec::new(),
+                        relevance_score: 0.0,
+                        final_score: 0.0,
+                    },
+                );
+            }
             let mut hits = Vec::new();
             for mut msg in messages {
                 let cl = msg.content_lower();
@@ -416,7 +445,10 @@ pub fn scored_search(
     // Quality gate with fallback (matches Python behavior)
     let quality: Vec<(Session, Message)> = capped
         .iter()
-        .filter(|(_, m)| m.final_score >= 0.5 && m.content.len() >= 40)
+        .filter(|(_, m)| {
+            m.final_score >= 0.5
+                && (m.content.len() >= 40 || m.uuid == "index-title")
+        })
         .cloned()
         .collect();
     let mut final_results = if quality.is_empty() { capped } else { quality };
@@ -589,10 +621,21 @@ mod tests {
         let results = vec![IndexResult {
             session: make_session("1", "test", "", "proj", "main"),
             score: 2.0,
-            matched_field: "summary".into(),
-            display: "test".into(),
+            matched_field: "project".into(),
+            display: "proj".into(),
         }];
         assert!(!index_quality_ok(&results));
+    }
+
+    #[test]
+    fn index_quality_ok_title_match_when_recency_damps_score() {
+        let results = vec![IndexResult {
+            session: make_session("1", "review mergeability checks", "", "proj", "main"),
+            score: 4.5,
+            matched_field: "summary".into(),
+            display: "review mergeability checks".into(),
+        }];
+        assert!(index_quality_ok(&results));
     }
 
     #[test]
@@ -613,8 +656,8 @@ mod tests {
         let below = vec![IndexResult {
             session: make_session("1", "test", "", "proj", "main"),
             score: INDEX_QUALITY_THRESHOLD - 0.1,
-            matched_field: "summary".into(),
-            display: "test".into(),
+            matched_field: "project".into(),
+            display: "proj".into(),
         }];
         assert!(!index_quality_ok(&below));
     }
@@ -638,5 +681,35 @@ mod tests {
         );
         let capped = boost.min(MAX_TOTAL_BOOST);
         assert_eq!(capped, MAX_TOTAL_BOOST, "capped boost should equal limit");
+    }
+
+    #[test]
+    fn scored_search_includes_session_title_when_absent_from_transcript() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let data = concat!(
+            r#"{"type":"user","message":{"role":"user","content":"please look at the checkout workflow"},"timestamp":"2026-08-14T00:00:00Z","uuid":"u1"}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"role":"assistant","content":"I will inspect the github actions file and suggest safer git fetch flags."},"timestamp":"2026-08-14T00:01:00Z","uuid":"u2"}"#,
+        );
+        std::fs::write(tmp.path(), data).unwrap();
+        let mut s = make_session(
+            "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "review mergeability checks",
+            "please look at the checkout workflow",
+            "/home/alice/src/myapp",
+            "main",
+        );
+        s.file = tmp.path().to_str().unwrap().to_string();
+        let results = scored_search(&[s], "mergeability", "all", 10, None);
+        assert!(
+            results
+                .iter()
+                .any(|r| r.message.content.contains("mergeability")),
+            "expected title hit, got {:?}",
+            results
+                .iter()
+                .map(|r| r.message.content.clone())
+                .collect::<Vec<_>>()
+        );
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -443,10 +443,7 @@ pub fn scored_search(
     // Quality gate with fallback (matches Python behavior)
     let quality: Vec<(Session, Message)> = capped
         .iter()
-        .filter(|(_, m)| {
-            m.final_score >= 0.5
-                && (m.content.len() >= 40 || m.uuid == "index-title")
-        })
+        .filter(|(_, m)| m.final_score >= 0.5 && (m.content.len() >= 40 || m.uuid == "index-title"))
         .cloned()
         .collect();
     let mut final_results = if quality.is_empty() { capped } else { quality };

--- a/src/session.rs
+++ b/src/session.rs
@@ -262,22 +262,37 @@ pub fn copy_session_to_dir(session: &Session, target_dir: &Path) -> std::io::Res
     Ok(())
 }
 
+/// How to resume a session in its original tool.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ResumeAction {
+    Exec { bin: String, args: Vec<String> },
+    Print { cmdline: String },
+}
+
 /// Binary + args to resume this session in its original tool.
-/// Cursor uses `agent --resume <id>` (falls back to `cursor agent` if needed).
-pub fn resume_command(session: &Session) -> Option<(String, Vec<String>)> {
+/// Cursor Agent: `agent`, then `cursor-agent`, never exec `cursor agent`
+/// (that launcher can download the CLI as a side effect).
+pub fn resume_command(session: &Session) -> Option<ResumeAction> {
     match session.source.as_str() {
-        "codex" => Some(("codex".into(), vec!["resume".into(), session.id.clone()])),
-        "claude" => Some((
-            "claude".into(),
-            vec!["--resume".into(), session.id.clone()],
-        )),
-        "cursor-agent" => {
+        "codex" => Some(ResumeAction::Exec {
+            bin: "codex".into(),
+            args: vec!["resume".into(), session.id.clone()],
+        }),
+        "claude" => Some(ResumeAction::Exec {
+            bin: "claude".into(),
+            args: vec!["--resume".into(), session.id.clone()],
+        }),
+        "cursor" => {
             let mut args = Vec::new();
-            let bin = if command_on_path("agent") {
-                "agent".into()
-            } else {
+            let (bin, print_only) = if command_on_path("agent") {
+                ("agent".into(), false)
+            } else if command_on_path("cursor-agent") {
+                ("cursor-agent".into(), false)
+            } else if command_on_path("cursor") {
                 args.push("agent".into());
-                "cursor".into()
+                ("cursor".into(), true)
+            } else {
+                ("agent".into(), false)
             };
             args.push("--resume".into());
             args.push(session.id.clone());
@@ -285,7 +300,15 @@ pub fn resume_command(session: &Session) -> Option<(String, Vec<String>)> {
                 args.push("--workspace".into());
                 args.push(session.project.clone());
             }
-            Some((bin, args))
+            if print_only {
+                let cmdline = std::iter::once(bin)
+                    .chain(args.iter().cloned())
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                Some(ResumeAction::Print { cmdline })
+            } else {
+                Some(ResumeAction::Exec { bin, args })
+            }
         }
         _ => None,
     }
@@ -555,63 +578,66 @@ fn cursor_workspace_dir(project_dir: &Path) -> String {
         .file_name()
         .unwrap_or_default()
         .to_string_lossy();
-    decode_cursor_project_slug(&slug)
+    match decode_cursor_project_slug(&slug) {
+        WorkspaceResolution::Exact(p) => p.to_string_lossy().into_owned(),
+        _ => slug.into_owned(),
+    }
 }
 
-fn decode_cursor_project_slug(slug: &str) -> String {
+#[derive(Debug, PartialEq, Eq)]
+pub enum WorkspaceResolution {
+    Exact(PathBuf),
+    Ambiguous,
+    Missing,
+}
+
+/// Decode a Cursor project folder slug. Hyphen splits are not unique
+/// (`a-b/c` vs `a/b-c`), so only a single existing path is trusted.
+pub fn decode_cursor_project_slug(slug: &str) -> WorkspaceResolution {
+    decode_from_root(Path::new("/"), slug)
+}
+
+fn decode_from_root(root: &Path, slug: &str) -> WorkspaceResolution {
     if slug.is_empty() {
-        return String::new();
+        return WorkspaceResolution::Missing;
     }
-    let greedy = match_slug_to_existing_path(Path::new("/"), slug);
-    if Path::new(&greedy).is_dir() {
-        return greedy;
+    let mut found = existing_slug_paths(root, slug);
+    found.sort();
+    found.dedup();
+    match found.len() {
+        1 => WorkspaceResolution::Exact(found.remove(0)),
+        0 => WorkspaceResolution::Missing,
+        _ => WorkspaceResolution::Ambiguous,
     }
-    let naive = format!("/{}", slug.replace('-', "/"));
-    if Path::new(&naive).is_dir() {
-        return naive;
-    }
-    slug.to_string()
 }
 
-fn match_slug_to_existing_path(root: &Path, slug: &str) -> String {
-    let mut current = root.to_path_buf();
-    let mut rest = slug;
-    while !rest.is_empty() {
-        let Ok(entries) = fs::read_dir(&current) else {
-            current.push(rest);
-            break;
+fn existing_slug_paths(root: &Path, rest: &str) -> Vec<PathBuf> {
+    if rest.is_empty() {
+        return if root.is_dir() {
+            vec![root.to_path_buf()]
+        } else {
+            Vec::new()
         };
-        let mut best: Option<String> = None;
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if !path.is_dir() {
-                continue;
-            }
-            let name = entry.file_name().to_string_lossy().into_owned();
-            let matched = rest == name
-                || rest
-                    .strip_prefix(&name)
-                    .is_some_and(|tail| tail.is_empty() || tail.starts_with('-'));
-            if matched && best.as_ref().is_none_or(|b| name.len() > b.len()) {
-                best = Some(name);
-            }
+    }
+    let Ok(entries) = fs::read_dir(root) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
         }
-        match best {
-            Some(name) => {
-                let skip = name.len();
-                current.push(&name);
-                rest = rest.get(skip..).unwrap_or("");
-                if rest.starts_with('-') {
-                    rest = &rest[1..];
-                }
-            }
-            None => {
-                current.push(rest);
-                break;
-            }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if rest == name {
+            out.push(path);
+        } else if let Some(after) = rest.strip_prefix(&name)
+            && let Some(tail) = after.strip_prefix('-')
+        {
+            out.extend(existing_slug_paths(&path, tail));
         }
     }
-    current.to_string_lossy().into_owned()
+    out
 }
 
 pub fn load_cursor_sessions() -> Vec<Session> {
@@ -650,7 +676,7 @@ pub fn load_cursor_sessions() -> Vec<Session> {
                             path.to_string_lossy().to_string()
                         };
                         sessions.push(Session {
-                            source: "cursor-agent".into(),
+                            source: "cursor".into(),
                             id: sid,
                             summary: String::new(),
                             first_prompt: first,
@@ -690,7 +716,7 @@ pub fn load_cursor_sessions() -> Vec<Session> {
                         let date = mtime_date(&subagent_path).unwrap_or_default();
                         let first = cursor_first_prompt_jsonl(&subagent_path);
                         sessions.push(Session {
-                            source: "cursor-agent".into(),
+                            source: "cursor".into(),
                             id: sid,
                             summary: String::new(),
                             first_prompt: first,
@@ -716,7 +742,7 @@ pub fn load_cursor_sessions() -> Vec<Session> {
                 let date = mtime_date(&jf).unwrap_or_default();
                 let first = cursor_first_prompt_jsonl(&jf);
                 sessions.push(Session {
-                    source: "cursor-agent".into(),
+                    source: "cursor".into(),
                     id: dirname,
                     summary: String::new(),
                     first_prompt: first,
@@ -885,35 +911,74 @@ pub fn load_codex_sessions() -> Vec<Session> {
 }
 
 pub fn load_all_sessions() -> Vec<Session> {
-    let mut all = load_claude_sessions();
-    all.extend(merge_cursor_sessions(
-        load_cursor_sessions(),
-        crate::cursor_ide::load_cursor_ide_sessions(),
-    ));
-    all.extend(load_codex_sessions());
+    load_sessions(None)
+}
+
+/// `cursor-agent` is an alias for the existing Agent transcript source `cursor`.
+pub fn normalize_source_filter(source: Option<&str>) -> Option<String> {
+    match source {
+        None => None,
+        Some("cursor-agent") => Some("cursor".into()),
+        Some(s) => Some(s.to_string()),
+    }
+}
+
+pub fn load_sessions(source: Option<&str>) -> Vec<Session> {
+    let src = normalize_source_filter(source);
+    let load_all = src.is_none();
+    let mut all = Vec::new();
+    if load_all || src.as_deref() == Some("claude") {
+        all.extend(load_claude_sessions());
+    }
+    let load_agent = load_all || src.as_deref() == Some("cursor");
+    let load_ide = load_all || src.as_deref() == Some("cursor-ide");
+    if load_agent || load_ide {
+        let agents = if load_agent {
+            load_cursor_sessions()
+        } else {
+            Vec::new()
+        };
+        let ide = if load_ide {
+            crate::cursor_ide::load_cursor_ide_sessions()
+        } else {
+            Vec::new()
+        };
+        all.extend(merge_cursor_sessions(agents, ide));
+    }
+    if load_all || src.as_deref() == Some("codex") {
+        all.extend(load_codex_sessions());
+    }
     all
 }
 
-/// Overlay IDE sidebar titles/paths onto matching agent transcripts.
-/// Keep both rows: jsonl stays `cursor-agent`, SQLite stays `cursor`.
+/// Overlay IDE sidebar titles/paths onto every Agent copy of that id.
+/// Keep an IDE-only row only when it has bubbles and no Agent transcript.
 pub fn merge_cursor_sessions(agents: Vec<Session>, ide: Vec<Session>) -> Vec<Session> {
     let mut agents = agents;
-    let mut by_id: HashMap<String, usize> = HashMap::new();
-    for (i, s) in agents.iter().enumerate() {
-        by_id.insert(s.id.to_ascii_lowercase(), i);
+    let mut agent_indexes: HashMap<String, Vec<usize>> = HashMap::new();
+    for (index, session) in agents.iter().enumerate() {
+        agent_indexes
+            .entry(session.id.to_ascii_lowercase())
+            .or_default()
+            .push(index);
     }
-    for ide_s in &ide {
-        let key = ide_s.id.to_ascii_lowercase();
-        if let Some(&i) = by_id.get(&key) {
-            if !ide_s.summary.is_empty() {
-                agents[i].summary = ide_s.summary.clone();
+    let mut ide_only = Vec::new();
+    for ide_session in ide {
+        let key = ide_session.id.to_ascii_lowercase();
+        if let Some(indexes) = agent_indexes.get(&key) {
+            for &index in indexes {
+                if !ide_session.summary.is_empty() {
+                    agents[index].summary = ide_session.summary.clone();
+                }
+                if !ide_session.project.is_empty() {
+                    agents[index].project = ide_session.project.clone();
+                }
             }
-            if !ide_s.project.is_empty() {
-                agents[i].project = ide_s.project.clone();
-            }
+        } else if ide_session.messages > 0 {
+            ide_only.push(ide_session);
         }
     }
-    agents.extend(ide);
+    agents.extend(ide_only);
     agents
 }
 
@@ -1378,13 +1443,30 @@ pub fn parse_session(session: &Session, extract_meta: bool) -> (Vec<Message>, Op
         }
         return (messages, None);
     }
+    if session.source == "cursor-ide" {
+        let messages = crate::cursor_ide::parse_cursor_ide(session);
+        if extract_meta {
+            return (
+                messages,
+                Some(SessionMeta {
+                    summary: if session.summary.is_empty() {
+                        None
+                    } else {
+                        Some(session.summary.clone())
+                    },
+                    custom_title: None,
+                    model: None,
+                    total_tokens: 0,
+                }),
+            );
+        }
+        return (messages, None);
+    }
     if session.source == "cursor" {
-        let messages = if session.file.ends_with(".jsonl") {
-            parse_cursor_jsonl(&session.file)
-        } else if session.file.ends_with(".txt") {
+        let messages = if session.file.ends_with(".txt") {
             parse_cursor_txt(&session.file)
         } else {
-            crate::cursor_ide::parse_cursor_ide(session)
+            parse_cursor_jsonl(&session.file)
         };
         if extract_meta {
             return (
@@ -1458,7 +1540,7 @@ pub fn filter_sessions(
                     return false;
                 }
             }
-            if let Some(src) = source
+            if let Some(src) = normalize_source_filter(source).as_deref()
                 && s.source != src
             {
                 return false;
@@ -1517,8 +1599,17 @@ pub fn lookup_session<'a>(sessions: &'a [Session], sid: &str) -> SessionLookup<'
     if matches.is_empty() {
         return SessionLookup::NotFound;
     }
-    let distinct: HashSet<String> = matches.iter().map(|s| s.id.to_ascii_lowercase()).collect();
-    if distinct.len() == 1 {
+    if matches.len() == 1 {
+        return SessionLookup::Found(matches[0]);
+    }
+    let one_id = matches
+        .iter()
+        .map(|s| s.id.to_ascii_lowercase())
+        .collect::<HashSet<_>>()
+        .len()
+        == 1;
+    let all_cursor_copies = matches.iter().all(|s| s.source == "cursor");
+    if one_id && all_cursor_copies {
         return SessionLookup::Found(prefer_session_copy(&matches));
     }
     SessionLookup::Ambiguous(matches)
@@ -1543,9 +1634,12 @@ fn matching_sessions<'a>(sessions: &'a [Session], sid: &str) -> Vec<&'a Session>
 
 /// Same conversation stored under more than one Cursor project folder.
 pub fn session_copies<'a>(sessions: &'a [Session], session: &Session) -> Vec<&'a Session> {
+    if session.source != "cursor" {
+        return Vec::new();
+    }
     sessions
         .iter()
-        .filter(|s| s.source == session.source && s.id.eq_ignore_ascii_case(&session.id))
+        .filter(|s| s.source == "cursor" && s.id.eq_ignore_ascii_case(&session.id))
         .collect()
 }
 
@@ -1553,31 +1647,25 @@ pub fn copy_count(sessions: &[Session], session: &Session) -> usize {
     session_copies(sessions, session).len()
 }
 
+fn project_matches_cwd(cwd: &Path, project: &str) -> bool {
+    if project.is_empty() {
+        return false;
+    }
+    let cwd = fs::canonicalize(cwd).unwrap_or_else(|_| cwd.to_path_buf());
+    let project = PathBuf::from(project);
+    let project = fs::canonicalize(&project).unwrap_or(project);
+    project == cwd || cwd.starts_with(&project) || project.starts_with(&cwd)
+}
+
 /// Prefer the copy whose workspace matches cwd; otherwise the newest.
-/// When the same id exists as both IDE (`cursor`) and jsonl (`cursor-agent`),
-/// resume/inspect pick the agent transcript.
 fn prefer_session_copy<'a>(copies: &[&'a Session]) -> &'a Session {
     if copies.len() == 1 {
         return copies[0];
     }
-    let agent_copies: Vec<&Session> = copies
-        .iter()
-        .copied()
-        .filter(|s| s.source == "cursor-agent")
-        .collect();
-    if !agent_copies.is_empty() && agent_copies.len() < copies.len() {
-        return prefer_session_copy(&agent_copies);
-    }
     if let Ok(cwd) = std::env::current_dir() {
-        let cwd_s = cwd.to_string_lossy();
         let cwd_hits: Vec<&&Session> = copies
             .iter()
-            .filter(|s| {
-                !s.project.is_empty()
-                    && (cwd_s == s.project
-                        || cwd_s.starts_with(&format!("{}/", s.project))
-                        || s.project.starts_with(cwd_s.as_ref()))
-            })
+            .filter(|s| project_matches_cwd(&cwd, &s.project))
             .collect();
         if cwd_hits.len() == 1 {
             return cwd_hits[0];
@@ -1660,13 +1748,26 @@ mod tests {
         let claude = make_session("c1", "2026-01-01", "claude", "/p", "", "");
         assert_eq!(
             resume_command(&claude),
-            Some(("claude".into(), vec!["--resume".into(), "c1".into()]))
+            Some(ResumeAction::Exec {
+                bin: "claude".into(),
+                args: vec!["--resume".into(), "c1".into()]
+            })
         );
         let codex = make_session("x1", "2026-01-01", "codex", "/p", "", "");
         assert_eq!(
             resume_command(&codex),
-            Some(("codex".into(), vec!["resume".into(), "x1".into()]))
+            Some(ResumeAction::Exec {
+                bin: "codex".into(),
+                args: vec!["resume".into(), "x1".into()]
+            })
         );
+    }
+
+    fn resume_exec_args(session: &Session) -> (String, Vec<String>) {
+        match resume_command(session).expect("resume") {
+            ResumeAction::Exec { bin, args } => (bin, args),
+            ResumeAction::Print { cmdline } => panic!("expected exec, got print {cmdline}"),
+        }
     }
 
     #[test]
@@ -1674,13 +1775,13 @@ mod tests {
         let missing = make_session(
             "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
             "2026-08-26",
-            "cursor-agent",
+            "cursor",
             "/no/such/cursor/ws",
             "",
             "",
         );
-        let (bin, args) = resume_command(&missing).expect("cursor resume");
-        assert!(bin == "agent" || bin == "cursor");
+        let (bin, args) = resume_exec_args(&missing);
+        assert!(bin == "agent" || bin == "cursor-agent");
         assert!(args.iter().any(|a| a == "--resume"));
         assert!(args.iter().any(|a| a == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"));
         assert!(!args.iter().any(|a| a == "--workspace"));
@@ -1690,12 +1791,12 @@ mod tests {
         let present = make_session(
             "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
             "2026-08-26",
-            "cursor-agent",
+            "cursor",
             &ws,
             "",
             "",
         );
-        let (_, args) = resume_command(&present).expect("cursor resume with workspace");
+        let (_, args) = resume_exec_args(&present);
         assert!(
             args.windows(2)
                 .any(|w| w[0] == "--workspace" && w[1] == ws)
@@ -1704,13 +1805,13 @@ mod tests {
 
     #[test]
     fn resume_working_dir_requires_existing_folder() {
-        let missing = make_session("id", "2026-01-01", "cursor-agent", "/no/such/ws", "", "");
+        let missing = make_session("id", "2026-01-01", "cursor", "/no/such/ws", "", "");
         assert!(resume_working_dir(&missing).is_none());
         let dir = tempfile::TempDir::new().unwrap();
         let present = make_session(
             "id",
             "2026-01-01",
-            "cursor-agent",
+            "cursor",
             dir.path().to_str().unwrap(),
             "",
             "",
@@ -1727,8 +1828,8 @@ mod tests {
         let ws = root.path().join("devops").join("chat-history");
         fs::create_dir_all(&ws).unwrap();
         assert_eq!(
-            match_slug_to_existing_path(root.path(), "devops-chat-history"),
-            ws.to_string_lossy()
+            decode_from_root(root.path(), "devops-chat-history"),
+            WorkspaceResolution::Exact(ws)
         );
     }
 
@@ -1736,7 +1837,18 @@ mod tests {
     fn cursor_slug_falls_back_to_slug_when_path_missing() {
         assert_eq!(
             decode_cursor_project_slug("zz-no-such-cursor-ws-xyz"),
-            "zz-no-such-cursor-ws-xyz"
+            WorkspaceResolution::Missing
+        );
+    }
+
+    #[test]
+    fn cursor_slug_ambiguous_hyphen_split() {
+        let root = tempfile::TempDir::new().unwrap();
+        fs::create_dir_all(root.path().join("a-b").join("c")).unwrap();
+        fs::create_dir_all(root.path().join("a").join("b-c")).unwrap();
+        assert_eq!(
+            decode_from_root(root.path(), "a-b-c"),
+            WorkspaceResolution::Ambiguous
         );
     }
 
@@ -1780,54 +1892,73 @@ mod tests {
 
     #[test]
     fn merge_cursor_copies_ide_title_onto_agent_transcript() {
-        let agents = vec![make_session(
+        let agents = vec![
+            make_session(
+                "11111111-2222-3333-4444-555555555555",
+                "2026-08-01",
+                "cursor",
+                "Users-test-myapp",
+                "",
+                "",
+            ),
+            make_session(
+                "11111111-2222-3333-4444-555555555555",
+                "2026-08-02",
+                "cursor",
+                "Users-test-myapp-tmp",
+                "",
+                "",
+            ),
+        ];
+        let mut ide = make_session(
             "11111111-2222-3333-4444-555555555555",
             "2026-08-01",
-            "cursor-agent",
-            "Users-test-myapp",
-            "",
-            "",
-        )];
-        let ide = make_session(
-            "11111111-2222-3333-4444-555555555555",
-            "2026-08-01",
-            "cursor",
+            "cursor-ide",
             "/home/alice/src/myapp",
             "",
             "Fix the login timeout",
         );
+        ide.messages = 4;
         let merged = merge_cursor_sessions(agents, vec![ide]);
         assert_eq!(merged.len(), 2);
-        let agent = merged.iter().find(|s| s.source == "cursor-agent").unwrap();
-        let ide_row = merged.iter().find(|s| s.source == "cursor").unwrap();
-        assert_eq!(agent.summary, "Fix the login timeout");
-        assert_eq!(agent.project, "/home/alice/src/myapp");
-        assert_eq!(ide_row.summary, "Fix the login timeout");
+        assert!(merged.iter().all(|s| s.source == "cursor"));
+        assert!(merged.iter().all(|s| s.summary == "Fix the login timeout"));
+        assert!(merged.iter().all(|s| s.project == "/home/alice/src/myapp"));
     }
 
     #[test]
-    fn merge_cursor_keeps_ide_row_as_cursor() {
+    fn merge_cursor_keeps_ide_only_row_with_bubbles() {
         let agents = vec![make_session(
             "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
             "2026-08-01",
-            "cursor-agent",
+            "cursor",
             "Users-test-myapp",
             "",
             "",
         )];
-        let ide = make_session(
-            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        let mut ide = make_session(
+            "ffffffff-1111-2222-3333-444444444444",
             "2026-08-01",
-            "cursor",
+            "cursor-ide",
             "/home/alice/src/myapp",
             "",
             "Explain the cache layer",
         );
-        let merged = merge_cursor_sessions(agents, vec![ide]);
+        ide.messages = 2;
+        let empty = make_session(
+            "00000000-1111-2222-3333-444444444444",
+            "2026-08-01",
+            "cursor-ide",
+            "",
+            "",
+            "ghost header",
+        );
+        let merged = merge_cursor_sessions(agents, vec![ide, empty]);
         assert_eq!(merged.len(), 2);
-        assert!(merged.iter().any(|s| s.source == "cursor-agent"));
-        let ide_row = merged.iter().find(|s| s.source == "cursor").unwrap();
+        assert!(merged.iter().any(|s| s.source == "cursor"));
+        let ide_row = merged.iter().find(|s| s.source == "cursor-ide").unwrap();
         assert_eq!(ide_row.summary, "Explain the cache layer");
+        assert!(!merged.iter().any(|s| s.summary == "ghost header"));
     }
 
     #[test]
@@ -1836,7 +1967,7 @@ mod tests {
             make_session(
                 "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
                 "2025-08-25",
-                "cursor-agent",
+                "cursor",
                 "/tmp",
                 "",
                 "old copy",
@@ -1844,7 +1975,7 @@ mod tests {
             make_session(
                 "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
                 "2025-08-26",
-                "cursor-agent",
+                "cursor",
                 "/home/alice/src/myapp",
                 "",
                 "new copy",
@@ -1857,15 +1988,15 @@ mod tests {
     }
 
     #[test]
-    fn lookup_session_prefers_agent_transcript_over_ide_row() {
-        let id = "cccccccc-dddd-eeee-ffff-000000000000";
+    fn lookup_session_same_id_claude_stays_ambiguous() {
+        let id = "dddddddd-eeee-ffff-aaaa-111111111111";
         let sessions = vec![
-            make_session(id, "2026-08-26", "cursor", "/home/alice/src/myapp", "", "sidebar title"),
-            make_session(id, "2026-08-20", "cursor-agent", "/home/alice/src/myapp", "", ""),
+            make_session(id, "2026-08-26", "claude", "/a", "", "one"),
+            make_session(id, "2026-08-20", "claude", "/b", "", "two"),
         ];
         match lookup_session(&sessions, id) {
-            SessionLookup::Found(s) => assert_eq!(s.source, "cursor-agent"),
-            other => panic!("expected Found, got {other:?}"),
+            SessionLookup::Ambiguous(c) => assert_eq!(c.len(), 2),
+            other => panic!("expected Ambiguous, got {other:?}"),
         }
     }
 
@@ -1937,7 +2068,7 @@ mod tests {
         let sessions = vec![make_session(
             "1",
             "2025-01-01",
-            "cursor-agent",
+            "cursor",
             "proj-one-two-123",
             "",
             "",
@@ -2089,7 +2220,7 @@ mod tests {
             make_session(
                 "2",
                 "2025-06-15",
-                "cursor-agent",
+                "cursor",
                 "chat-history",
                 "main",
                 "fix docker",

--- a/src/session.rs
+++ b/src/session.rs
@@ -294,7 +294,7 @@ pub fn resume_command(session: &Session) -> Option<ResumeAction> {
         }),
         "cursor" => {
             let mut args = Vec::new();
-            let (bin, print_only) = if command_on_path("agent") {
+            let (bin, print_only): (String, bool) = if command_on_path("agent") {
                 ("agent".into(), false)
             } else if command_on_path("cursor-agent") {
                 ("cursor-agent".into(), false)
@@ -311,8 +311,9 @@ pub fn resume_command(session: &Session) -> Option<ResumeAction> {
                 args.push(session.project.clone());
             }
             if print_only {
-                let cmdline = std::iter::once(bin)
-                    .chain(args.iter().cloned())
+                let cmdline = std::iter::once(bin.as_str())
+                    .chain(args.iter().map(String::as_str))
+                    .map(shell_quote)
                     .collect::<Vec<_>>()
                     .join(" ");
                 Some(ResumeAction::Print { cmdline })
@@ -321,6 +322,19 @@ pub fn resume_command(session: &Session) -> Option<ResumeAction> {
             }
         }
         _ => None,
+    }
+}
+
+/// Quote one argument for copy-paste into a POSIX shell.
+fn shell_quote(arg: &str) -> String {
+    let safe = !arg.is_empty()
+        && arg
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b"-_./:@%+=,".contains(&b));
+    if safe {
+        arg.to_string()
+    } else {
+        format!("'{}'", arg.replace('\'', "'\\''"))
     }
 }
 
@@ -1862,6 +1876,15 @@ mod tests {
             "sidebar title",
         );
         assert!(ide.is_ide_ui());
+    }
+
+    #[test]
+    fn shell_quote_protects_spaces_and_quotes() {
+        assert_eq!(shell_quote("plain-arg_1.0"), "plain-arg_1.0");
+        assert_eq!(shell_quote("/Users/a b/ws"), "'/Users/a b/ws'");
+        assert_eq!(shell_quote("it's"), "'it'\\''s'");
+        assert_eq!(shell_quote("$HOME"), "'$HOME'");
+        assert_eq!(shell_quote(""), "''");
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -2049,7 +2049,9 @@ mod tests {
                 "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
                 "2025-08-25",
                 "cursor",
-                "/tmp",
+                // Must not exist: an existing path that contains the test
+                // cwd (e.g. `/tmp` on macOS) would win the cwd-match rule.
+                "/no/such/old/copy",
                 "",
                 "old copy",
             ),

--- a/src/session.rs
+++ b/src/session.rs
@@ -24,6 +24,16 @@ pub struct Session {
     pub project: String,
     pub file: String,
     pub is_sidechain: bool,
+    /// Same composer id also exists in Cursor IDE SQLite (sidebar chat).
+    pub also_ide: bool,
+}
+
+impl Session {
+    /// Listed as `cursor-ide`: SQLite-only composers, or IDE Agent chats that
+    /// also have an `agent-transcripts` jsonl with the same id.
+    pub fn is_ide_ui(&self) -> bool {
+        self.source == "cursor-ide" || self.also_ide
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -513,6 +523,7 @@ pub fn load_claude_sessions() -> Vec<Session> {
                 project: entry.project_path,
                 file: entry.full_path,
                 is_sidechain: entry.is_sidechain,
+                also_ide: false,
             });
         }
     }
@@ -561,6 +572,7 @@ pub fn load_claude_sessions() -> Vec<Session> {
                         project,
                         file: path.to_string_lossy().to_string(),
                         is_sidechain: false,
+                        also_ide: false,
                     });
                 }
             }
@@ -688,6 +700,7 @@ pub fn load_cursor_sessions() -> Vec<Session> {
                             project: project.clone(),
                             file,
                             is_sidechain: false,
+                            also_ide: false,
                         });
                     } else if path.is_dir() {
                         let dirname = path
@@ -728,6 +741,7 @@ pub fn load_cursor_sessions() -> Vec<Session> {
                             project: project.clone(),
                             file: subagent_path.to_string_lossy().to_string(),
                             is_sidechain: true,
+                            also_ide: false,
                         });
                     }
                 }
@@ -754,6 +768,7 @@ pub fn load_cursor_sessions() -> Vec<Session> {
                     project: project.clone(),
                     file: jf.to_string_lossy().to_string(),
                     is_sidechain: false,
+                    also_ide: false,
                 });
             }
         }
@@ -905,6 +920,7 @@ pub fn load_codex_sessions() -> Vec<Session> {
             project: meta.cwd,
             file: path.to_string_lossy().to_string(),
             is_sidechain: false,
+            also_ide: false,
         });
     }
     sessions
@@ -953,6 +969,7 @@ pub fn load_sessions(source: Option<&str>) -> Vec<Session> {
 
 /// Overlay IDE sidebar titles/paths onto every Agent copy of that id.
 /// Keep an IDE-only row only when it has bubbles and no Agent transcript.
+/// Matching pairs are one Agent row (`also_ide`) so search does not duplicate.
 pub fn merge_cursor_sessions(agents: Vec<Session>, ide: Vec<Session>) -> Vec<Session> {
     let mut agents = agents;
     let mut agent_indexes: HashMap<String, Vec<usize>> = HashMap::new();
@@ -967,6 +984,7 @@ pub fn merge_cursor_sessions(agents: Vec<Session>, ide: Vec<Session>) -> Vec<Ses
         let key = ide_session.id.to_ascii_lowercase();
         if let Some(indexes) = agent_indexes.get(&key) {
             for &index in indexes {
+                agents[index].also_ide = true;
                 if !ide_session.summary.is_empty() {
                     agents[index].summary = ide_session.summary.clone();
                 }
@@ -1608,8 +1626,18 @@ pub fn lookup_session<'a>(sessions: &'a [Session], sid: &str) -> SessionLookup<'
         .collect::<HashSet<_>>()
         .len()
         == 1;
-    let all_cursor_copies = matches.iter().all(|s| s.source == "cursor");
-    if one_id && all_cursor_copies {
+    let all_cursor_family = matches
+        .iter()
+        .all(|s| s.source == "cursor" || s.source == "cursor-ide");
+    if one_id && all_cursor_family {
+        let agent_copies: Vec<&Session> = matches
+            .iter()
+            .copied()
+            .filter(|s| s.source == "cursor")
+            .collect();
+        if !agent_copies.is_empty() {
+            return SessionLookup::Found(prefer_session_copy(&agent_copies));
+        }
         return SessionLookup::Found(prefer_session_copy(&matches));
     }
     SessionLookup::Ambiguous(matches)
@@ -1726,6 +1754,7 @@ mod tests {
             project: project.into(),
             file: String::new(),
             is_sidechain: false,
+            also_ide: false,
         }
     }
 
@@ -1801,6 +1830,30 @@ mod tests {
             args.windows(2)
                 .any(|w| w[0] == "--workspace" && w[1] == ws)
         );
+    }
+
+    #[test]
+    fn ide_ui_includes_agent_transcript_with_matching_composer() {
+        let mut session = make_session(
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "2026-08-26",
+            "cursor",
+            "/tmp",
+            "",
+            "sidebar title",
+        );
+        assert!(!session.is_ide_ui());
+        session.also_ide = true;
+        assert!(session.is_ide_ui());
+        let ide = make_session(
+            "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+            "2026-08-26",
+            "cursor-ide",
+            "/tmp",
+            "",
+            "sidebar title",
+        );
+        assert!(ide.is_ide_ui());
     }
 
     #[test]
@@ -1924,6 +1977,7 @@ mod tests {
         assert!(merged.iter().all(|s| s.source == "cursor"));
         assert!(merged.iter().all(|s| s.summary == "Fix the login timeout"));
         assert!(merged.iter().all(|s| s.project == "/home/alice/src/myapp"));
+        assert!(merged.iter().all(|s| s.also_ide));
     }
 
     #[test]
@@ -1958,7 +2012,37 @@ mod tests {
         assert!(merged.iter().any(|s| s.source == "cursor"));
         let ide_row = merged.iter().find(|s| s.source == "cursor-ide").unwrap();
         assert_eq!(ide_row.summary, "Explain the cache layer");
+        assert!(!ide_row.also_ide);
         assert!(!merged.iter().any(|s| s.summary == "ghost header"));
+    }
+
+    #[test]
+    fn lookup_session_same_id_prefers_agent_over_ide() {
+        let sessions = vec![
+            make_session(
+                "11111111-2222-3333-4444-555555555555",
+                "2026-08-01",
+                "cursor",
+                "/tmp",
+                "",
+                "agent copy",
+            ),
+            make_session(
+                "11111111-2222-3333-4444-555555555555",
+                "2026-08-01",
+                "cursor-ide",
+                "/home/alice/src/myapp",
+                "",
+                "sidebar title",
+            ),
+        ];
+        match lookup_session(&sessions, "11111111") {
+            SessionLookup::Found(s) => {
+                assert_eq!(s.source, "cursor");
+                assert_eq!(s.summary, "agent copy");
+            }
+            other => panic!("expected agent copy, got {other:?}"),
+        }
     }
 
     #[test]
@@ -2494,6 +2578,7 @@ mod tests {
             project: String::new(),
             file: src_file.to_string_lossy().to_string(),
             is_sidechain: false,
+            also_ide: false,
         };
 
         let target = tmp.path().join("target-dir");

--- a/src/session.rs
+++ b/src/session.rs
@@ -293,6 +293,9 @@ pub fn resume_command(session: &Session) -> Option<ResumeAction> {
             args: vec!["--resume".into(), session.id.clone()],
         }),
         "cursor" => {
+            // Only chats the Agent CLI itself stored can be resumed, and only
+            // from their own workspace; anything else would start a blank chat.
+            let cwd = cursor_cli_chat_cwd(&session.id)?;
             let mut args = Vec::new();
             let (bin, print_only): (String, bool) = if command_on_path("agent") {
                 ("agent".into(), false)
@@ -306,10 +309,8 @@ pub fn resume_command(session: &Session) -> Option<ResumeAction> {
             };
             args.push("--resume".into());
             args.push(session.id.clone());
-            if existing_absolute_dir(&session.project).is_some() {
-                args.push("--workspace".into());
-                args.push(session.project.clone());
-            }
+            args.push("--workspace".into());
+            args.push(cwd.to_string_lossy().into_owned());
             if print_only {
                 let cmdline = std::iter::once(bin.as_str())
                     .chain(args.iter().map(String::as_str))
@@ -340,7 +341,50 @@ fn shell_quote(arg: &str) -> String {
 
 /// Directory the resumed tool should start in (the session's spawn cwd).
 pub fn resume_working_dir(session: &Session) -> Option<PathBuf> {
+    if session.source == "cursor" {
+        return cursor_cli_chat_cwd(&session.id);
+    }
     existing_absolute_dir(&session.project)
+}
+
+/// Workspace of the Cursor Agent CLI chat with this id, if the CLI has a
+/// store for it. The CLI keeps its sessions under
+/// `~/.cursor/chats/<hash of cwd>/<chat id>/{store.db,meta.json}` and looks a
+/// chat up by (workspace, id): resuming from another `--workspace` silently
+/// starts a blank chat that reuses the id. IDE sidebar chats also write
+/// `agent-transcripts` but never have such a store, so they get the sidebar
+/// hint instead. Several stores for one id (different workspaces) resolve to
+/// the most recently updated one whose workspace still exists.
+pub fn cursor_cli_chat_cwd(chat_id: &str) -> Option<PathBuf> {
+    let chats = user_home()?.join(".cursor").join("chats");
+    cursor_cli_chat_cwd_in(&chats, chat_id)
+}
+
+fn cursor_cli_chat_cwd_in(chats_dir: &Path, chat_id: &str) -> Option<PathBuf> {
+    let mut best: Option<(i64, PathBuf)> = None;
+    for entry in fs::read_dir(chats_dir).ok()?.flatten() {
+        let meta_path = entry.path().join(chat_id).join("meta.json");
+        let Ok(raw) = fs::read_to_string(&meta_path) else {
+            continue;
+        };
+        let Ok(meta) = serde_json::from_str::<serde_json::Value>(&raw) else {
+            continue;
+        };
+        let Some(cwd) = meta.get("cwd").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let Some(dir) = existing_absolute_dir(cwd) else {
+            continue;
+        };
+        let updated = meta
+            .get("updatedAtMs")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+        if best.as_ref().is_none_or(|(t, _)| updated > *t) {
+            best = Some((updated, dir));
+        }
+    }
+    best.map(|(_, dir)| dir)
 }
 
 /// `project` as an existing, absolute directory. Cursor slugs that could not
@@ -1814,16 +1858,10 @@ mod tests {
         );
     }
 
-    fn resume_exec_args(session: &Session) -> (String, Vec<String>) {
-        match resume_command(session).expect("resume") {
-            ResumeAction::Exec { bin, args } => (bin, args),
-            ResumeAction::Print { cmdline } => panic!("expected exec, got print {cmdline}"),
-        }
-    }
-
     #[test]
-    fn resume_command_cursor_uses_resume_flag() {
-        let missing = make_session(
+    fn resume_command_cursor_needs_a_cli_chat_store() {
+        // No ~/.cursor/chats store for this id: nothing to resume.
+        let s = make_session(
             "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
             "2026-08-26",
             "cursor",
@@ -1831,27 +1869,37 @@ mod tests {
             "",
             "",
         );
-        let (bin, args) = resume_exec_args(&missing);
-        assert!(bin == "agent" || bin == "cursor-agent");
-        assert!(args.iter().any(|a| a == "--resume"));
-        assert!(
-            args.iter()
-                .any(|a| a == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
-        );
-        assert!(!args.iter().any(|a| a == "--workspace"));
+        assert!(resume_command(&s).is_none());
+        assert!(resume_working_dir(&s).is_none());
+    }
 
-        let dir = tempfile::TempDir::new().unwrap();
-        let ws = dir.path().to_string_lossy().into_owned();
-        let present = make_session(
-            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
-            "2026-08-26",
-            "cursor",
-            &ws,
-            "",
-            "",
+    #[test]
+    fn cursor_cli_chat_cwd_picks_newest_existing_workspace() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let chats = tmp.path().join("chats");
+        let ws_old = tmp.path().join("ws-old");
+        let ws_new = tmp.path().join("ws-new");
+        fs::create_dir_all(&ws_old).unwrap();
+        fs::create_dir_all(&ws_new).unwrap();
+        let id = "cc9ae34e-117f-435c-9a83-f8958c7b09e1";
+        let write = |hash: &str, cwd: &str, updated: i64| {
+            let dir = chats.join(hash).join(id);
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(
+                dir.join("meta.json"),
+                format!(r#"{{"schemaVersion":1,"cwd":{cwd:?},"updatedAtMs":{updated}}}"#),
+            )
+            .unwrap();
+        };
+        write("aaaa", ws_old.to_str().unwrap(), 1);
+        write("bbbb", ws_new.to_str().unwrap(), 2);
+        write("cccc", "/no/such/workspace", 3); // newest, but the workspace is gone
+        assert_eq!(cursor_cli_chat_cwd_in(&chats, id), Some(ws_new));
+        assert_eq!(cursor_cli_chat_cwd_in(&chats, "other-id"), None);
+        assert_eq!(
+            cursor_cli_chat_cwd_in(&tmp.path().join("missing"), id),
+            None
         );
-        let (_, args) = resume_exec_args(&present);
-        assert!(args.windows(2).any(|w| w[0] == "--workspace" && w[1] == ws));
     }
 
     #[test]
@@ -1891,13 +1939,8 @@ mod tests {
     fn relative_project_is_never_a_workspace() {
         // `src` exists relative to the package root, where cargo runs tests.
         // An undecoded Cursor slug looks exactly like this.
-        let s = make_session("id", "2026-01-01", "cursor", "src", "", "");
+        let s = make_session("id", "2026-01-01", "codex", "src", "", "");
         assert!(resume_working_dir(&s).is_none());
-        let mentions_workspace = match resume_command(&s).expect("cursor resume") {
-            ResumeAction::Exec { args, .. } => args.iter().any(|a| a == "--workspace"),
-            ResumeAction::Print { cmdline } => cmdline.contains("--workspace"),
-        };
-        assert!(!mentions_workspace);
         let cwd = std::env::current_dir().unwrap();
         assert!(!project_matches_cwd(&cwd.join("src"), "src"));
         assert!(project_matches_cwd(&cwd, cwd.to_str().unwrap()));
@@ -1905,13 +1948,13 @@ mod tests {
 
     #[test]
     fn resume_working_dir_requires_existing_folder() {
-        let missing = make_session("id", "2026-01-01", "cursor", "/no/such/ws", "", "");
+        let missing = make_session("id", "2026-01-01", "codex", "/no/such/ws", "", "");
         assert!(resume_working_dir(&missing).is_none());
         let dir = tempfile::TempDir::new().unwrap();
         let present = make_session(
             "id",
             "2026-01-01",
-            "cursor",
+            "codex",
             dir.path().to_str().unwrap(),
             "",
             "",

--- a/src/session.rs
+++ b/src/session.rs
@@ -306,7 +306,7 @@ pub fn resume_command(session: &Session) -> Option<ResumeAction> {
             };
             args.push("--resume".into());
             args.push(session.id.clone());
-            if !session.project.is_empty() && Path::new(&session.project).is_dir() {
+            if existing_absolute_dir(&session.project).is_some() {
                 args.push("--workspace".into());
                 args.push(session.project.clone());
             }
@@ -326,11 +326,19 @@ pub fn resume_command(session: &Session) -> Option<ResumeAction> {
 
 /// Directory the resumed tool should start in (the session's spawn cwd).
 pub fn resume_working_dir(session: &Session) -> Option<PathBuf> {
-    if session.project.is_empty() {
+    existing_absolute_dir(&session.project)
+}
+
+/// `project` as an existing, absolute directory. Cursor slugs that could not
+/// be decoded are kept verbatim (relative) for display; they must never be
+/// used as a cwd or `--workspace`, or a same-named subdirectory of the
+/// current directory would be picked up silently.
+fn existing_absolute_dir(project: &str) -> Option<PathBuf> {
+    if project.is_empty() {
         return None;
     }
-    let dir = PathBuf::from(&session.project);
-    dir.is_dir().then_some(dir)
+    let dir = PathBuf::from(project);
+    (dir.is_absolute() && dir.is_dir()).then_some(dir)
 }
 
 fn command_on_path(name: &str) -> bool {
@@ -1676,7 +1684,7 @@ pub fn copy_count(sessions: &[Session], session: &Session) -> usize {
 }
 
 fn project_matches_cwd(cwd: &Path, project: &str) -> bool {
-    if project.is_empty() {
+    if project.is_empty() || !Path::new(project).is_absolute() {
         return false;
     }
     let cwd = fs::canonicalize(cwd).unwrap_or_else(|_| cwd.to_path_buf());
@@ -1854,6 +1862,22 @@ mod tests {
             "sidebar title",
         );
         assert!(ide.is_ide_ui());
+    }
+
+    #[test]
+    fn relative_project_is_never_a_workspace() {
+        // `src` exists relative to the package root, where cargo runs tests.
+        // An undecoded Cursor slug looks exactly like this.
+        let s = make_session("id", "2026-01-01", "cursor", "src", "", "");
+        assert!(resume_working_dir(&s).is_none());
+        let mentions_workspace = match resume_command(&s).expect("cursor resume") {
+            ResumeAction::Exec { args, .. } => args.iter().any(|a| a == "--workspace"),
+            ResumeAction::Print { cmdline } => cmdline.contains("--workspace"),
+        };
+        assert!(!mentions_workspace);
+        let cwd = std::env::current_dir().unwrap();
+        assert!(!project_matches_cwd(&cwd.join("src"), "src"));
+        assert!(project_matches_cwd(&cwd, cwd.to_str().unwrap()));
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -1812,7 +1812,10 @@ mod tests {
         let (bin, args) = resume_exec_args(&missing);
         assert!(bin == "agent" || bin == "cursor-agent");
         assert!(args.iter().any(|a| a == "--resume"));
-        assert!(args.iter().any(|a| a == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"));
+        assert!(
+            args.iter()
+                .any(|a| a == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        );
         assert!(!args.iter().any(|a| a == "--workspace"));
 
         let dir = tempfile::TempDir::new().unwrap();
@@ -1826,10 +1829,7 @@ mod tests {
             "",
         );
         let (_, args) = resume_exec_args(&present);
-        assert!(
-            args.windows(2)
-                .any(|w| w[0] == "--workspace" && w[1] == ws)
-        );
+        assert!(args.windows(2).any(|w| w[0] == "--workspace" && w[1] == ws));
     }
 
     #[test]
@@ -1869,10 +1869,7 @@ mod tests {
             "",
             "",
         );
-        assert_eq!(
-            resume_working_dir(&present).as_deref(),
-            Some(dir.path())
-        );
+        assert_eq!(resume_working_dir(&present).as_deref(), Some(dir.path()));
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -4,7 +4,7 @@ use crate::parser::{
 use chrono::{DateTime, FixedOffset, NaiveDate, Utc};
 use serde::Deserialize;
 use serde_json::Value;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -262,6 +262,54 @@ pub fn copy_session_to_dir(session: &Session, target_dir: &Path) -> std::io::Res
     Ok(())
 }
 
+/// Binary + args to resume this session in its original tool.
+/// Cursor uses `agent --resume <id>` (falls back to `cursor agent` if needed).
+pub fn resume_command(session: &Session) -> Option<(String, Vec<String>)> {
+    match session.source.as_str() {
+        "codex" => Some(("codex".into(), vec!["resume".into(), session.id.clone()])),
+        "claude" => Some((
+            "claude".into(),
+            vec!["--resume".into(), session.id.clone()],
+        )),
+        "cursor-agent" => {
+            let mut args = Vec::new();
+            let bin = if command_on_path("agent") {
+                "agent".into()
+            } else {
+                args.push("agent".into());
+                "cursor".into()
+            };
+            args.push("--resume".into());
+            args.push(session.id.clone());
+            if !session.project.is_empty() && Path::new(&session.project).is_dir() {
+                args.push("--workspace".into());
+                args.push(session.project.clone());
+            }
+            Some((bin, args))
+        }
+        _ => None,
+    }
+}
+
+/// Directory the resumed tool should start in (the session's spawn cwd).
+pub fn resume_working_dir(session: &Session) -> Option<PathBuf> {
+    if session.project.is_empty() {
+        return None;
+    }
+    let dir = PathBuf::from(&session.project);
+    dir.is_dir().then_some(dir)
+}
+
+fn command_on_path(name: &str) -> bool {
+    let Some(paths) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&paths).any(|dir| {
+        let p = dir.join(name);
+        p.is_file()
+    })
+}
+
 fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
     fs::create_dir_all(dst)?;
     for entry in fs::read_dir(src)? {
@@ -498,6 +546,74 @@ pub fn load_claude_sessions() -> Vec<Session> {
     sessions
 }
 
+/// Cursor stores each workspace as `~/.cursor/projects/<slug>/` where `<slug>`
+/// is the absolute path with `/` replaced by `-`. Recover the spawn directory
+/// by matching existing path components so hyphenated folder names survive
+/// (e.g. `chat-history` stays one component, not `chat/history`).
+fn cursor_workspace_dir(project_dir: &Path) -> String {
+    let slug = project_dir
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy();
+    decode_cursor_project_slug(&slug)
+}
+
+fn decode_cursor_project_slug(slug: &str) -> String {
+    if slug.is_empty() {
+        return String::new();
+    }
+    let greedy = match_slug_to_existing_path(Path::new("/"), slug);
+    if Path::new(&greedy).is_dir() {
+        return greedy;
+    }
+    let naive = format!("/{}", slug.replace('-', "/"));
+    if Path::new(&naive).is_dir() {
+        return naive;
+    }
+    slug.to_string()
+}
+
+fn match_slug_to_existing_path(root: &Path, slug: &str) -> String {
+    let mut current = root.to_path_buf();
+    let mut rest = slug;
+    while !rest.is_empty() {
+        let Ok(entries) = fs::read_dir(&current) else {
+            current.push(rest);
+            break;
+        };
+        let mut best: Option<String> = None;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let matched = rest == name
+                || rest
+                    .strip_prefix(&name)
+                    .is_some_and(|tail| tail.is_empty() || tail.starts_with('-'));
+            if matched && best.as_ref().is_none_or(|b| name.len() > b.len()) {
+                best = Some(name);
+            }
+        }
+        match best {
+            Some(name) => {
+                let skip = name.len();
+                current.push(&name);
+                rest = rest.get(skip..).unwrap_or("");
+                if rest.starts_with('-') {
+                    rest = &rest[1..];
+                }
+            }
+            None => {
+                current.push(rest);
+                break;
+            }
+        }
+    }
+    current.to_string_lossy().into_owned()
+}
+
 pub fn load_cursor_sessions() -> Vec<Session> {
     let base = cursor_projects_dir();
     if !base.exists() {
@@ -511,6 +627,7 @@ pub fn load_cursor_sessions() -> Vec<Session> {
             if !transcripts.is_dir() {
                 continue;
             }
+            let project = cursor_workspace_dir(&pd.path());
             let mut txt_ids: HashSet<String> = HashSet::new();
             let mut dir_entries: Vec<(String, PathBuf)> = Vec::new();
             if let Ok(entries) = fs::read_dir(&transcripts) {
@@ -533,7 +650,7 @@ pub fn load_cursor_sessions() -> Vec<Session> {
                             path.to_string_lossy().to_string()
                         };
                         sessions.push(Session {
-                            source: "cursor".into(),
+                            source: "cursor-agent".into(),
                             id: sid,
                             summary: String::new(),
                             first_prompt: first,
@@ -542,7 +659,7 @@ pub fn load_cursor_sessions() -> Vec<Session> {
                             date,
                             messages: 0,
                             branch: String::new(),
-                            project: pd.file_name().to_string_lossy().to_string(),
+                            project: project.clone(),
                             file,
                             is_sidechain: false,
                         });
@@ -573,7 +690,7 @@ pub fn load_cursor_sessions() -> Vec<Session> {
                         let date = mtime_date(&subagent_path).unwrap_or_default();
                         let first = cursor_first_prompt_jsonl(&subagent_path);
                         sessions.push(Session {
-                            source: "cursor".into(),
+                            source: "cursor-agent".into(),
                             id: sid,
                             summary: String::new(),
                             first_prompt: first,
@@ -582,7 +699,7 @@ pub fn load_cursor_sessions() -> Vec<Session> {
                             date,
                             messages: 0,
                             branch: String::new(),
-                            project: pd.file_name().to_string_lossy().to_string(),
+                            project: project.clone(),
                             file: subagent_path.to_string_lossy().to_string(),
                             is_sidechain: true,
                         });
@@ -599,7 +716,7 @@ pub fn load_cursor_sessions() -> Vec<Session> {
                 let date = mtime_date(&jf).unwrap_or_default();
                 let first = cursor_first_prompt_jsonl(&jf);
                 sessions.push(Session {
-                    source: "cursor".into(),
+                    source: "cursor-agent".into(),
                     id: dirname,
                     summary: String::new(),
                     first_prompt: first,
@@ -608,7 +725,7 @@ pub fn load_cursor_sessions() -> Vec<Session> {
                     date,
                     messages: 0,
                     branch: String::new(),
-                    project: pd.file_name().to_string_lossy().to_string(),
+                    project: project.clone(),
                     file: jf.to_string_lossy().to_string(),
                     is_sidechain: false,
                 });
@@ -769,9 +886,35 @@ pub fn load_codex_sessions() -> Vec<Session> {
 
 pub fn load_all_sessions() -> Vec<Session> {
     let mut all = load_claude_sessions();
-    all.extend(load_cursor_sessions());
+    all.extend(merge_cursor_sessions(
+        load_cursor_sessions(),
+        crate::cursor_ide::load_cursor_ide_sessions(),
+    ));
     all.extend(load_codex_sessions());
     all
+}
+
+/// Overlay IDE sidebar titles/paths onto matching agent transcripts.
+/// Keep both rows: jsonl stays `cursor-agent`, SQLite stays `cursor`.
+pub fn merge_cursor_sessions(agents: Vec<Session>, ide: Vec<Session>) -> Vec<Session> {
+    let mut agents = agents;
+    let mut by_id: HashMap<String, usize> = HashMap::new();
+    for (i, s) in agents.iter().enumerate() {
+        by_id.insert(s.id.to_ascii_lowercase(), i);
+    }
+    for ide_s in &ide {
+        let key = ide_s.id.to_ascii_lowercase();
+        if let Some(&i) = by_id.get(&key) {
+            if !ide_s.summary.is_empty() {
+                agents[i].summary = ide_s.summary.clone();
+            }
+            if !ide_s.project.is_empty() {
+                agents[i].project = ide_s.project.clone();
+            }
+        }
+    }
+    agents.extend(ide);
+    agents
 }
 
 pub fn parse_claude_jsonl(
@@ -1235,6 +1378,31 @@ pub fn parse_session(session: &Session, extract_meta: bool) -> (Vec<Message>, Op
         }
         return (messages, None);
     }
+    if session.source == "cursor" {
+        let messages = if session.file.ends_with(".jsonl") {
+            parse_cursor_jsonl(&session.file)
+        } else if session.file.ends_with(".txt") {
+            parse_cursor_txt(&session.file)
+        } else {
+            crate::cursor_ide::parse_cursor_ide(session)
+        };
+        if extract_meta {
+            return (
+                messages,
+                Some(SessionMeta {
+                    summary: if session.summary.is_empty() {
+                        None
+                    } else {
+                        Some(session.summary.clone())
+                    },
+                    custom_title: None,
+                    model: None,
+                    total_tokens: 0,
+                }),
+            );
+        }
+        return (messages, None);
+    }
     let messages = if session.file.ends_with(".jsonl") {
         parse_cursor_jsonl(&session.file)
     } else {
@@ -1336,6 +1504,7 @@ pub fn recency_key(s: &Session) -> (Option<DateTime<FixedOffset>>, String) {
     (parse_any_timestamp(ts), ts.clone())
 }
 
+#[derive(Debug)]
 pub enum SessionLookup<'a> {
     Found(&'a Session),
     /// Multiple sessions share the prefix — never silently pick one.
@@ -1344,21 +1513,95 @@ pub enum SessionLookup<'a> {
 }
 
 pub fn lookup_session<'a>(sessions: &'a [Session], sid: &str) -> SessionLookup<'a> {
-    if let Some(s) = sessions.iter().find(|s| s.id.eq_ignore_ascii_case(sid)) {
-        return SessionLookup::Found(s);
+    let matches = matching_sessions(sessions, sid);
+    if matches.is_empty() {
+        return SessionLookup::NotFound;
     }
-    let matches: Vec<&Session> = sessions
+    let distinct: HashSet<String> = matches.iter().map(|s| s.id.to_ascii_lowercase()).collect();
+    if distinct.len() == 1 {
+        return SessionLookup::Found(prefer_session_copy(&matches));
+    }
+    SessionLookup::Ambiguous(matches)
+}
+
+fn matching_sessions<'a>(sessions: &'a [Session], sid: &str) -> Vec<&'a Session> {
+    let exact: Vec<&Session> = sessions
+        .iter()
+        .filter(|s| s.id.eq_ignore_ascii_case(sid))
+        .collect();
+    if !exact.is_empty() {
+        return exact;
+    }
+    sessions
         .iter()
         .filter(|s| {
             s.id.get(..sid.len())
                 .is_some_and(|prefix| prefix.eq_ignore_ascii_case(sid))
         })
-        .collect();
-    match matches.len() {
-        0 => SessionLookup::NotFound,
-        1 => SessionLookup::Found(matches[0]),
-        _ => SessionLookup::Ambiguous(matches),
+        .collect()
+}
+
+/// Same conversation stored under more than one Cursor project folder.
+pub fn session_copies<'a>(sessions: &'a [Session], session: &Session) -> Vec<&'a Session> {
+    sessions
+        .iter()
+        .filter(|s| s.source == session.source && s.id.eq_ignore_ascii_case(&session.id))
+        .collect()
+}
+
+pub fn copy_count(sessions: &[Session], session: &Session) -> usize {
+    session_copies(sessions, session).len()
+}
+
+/// Prefer the copy whose workspace matches cwd; otherwise the newest.
+/// When the same id exists as both IDE (`cursor`) and jsonl (`cursor-agent`),
+/// resume/inspect pick the agent transcript.
+fn prefer_session_copy<'a>(copies: &[&'a Session]) -> &'a Session {
+    if copies.len() == 1 {
+        return copies[0];
     }
+    let agent_copies: Vec<&Session> = copies
+        .iter()
+        .copied()
+        .filter(|s| s.source == "cursor-agent")
+        .collect();
+    if !agent_copies.is_empty() && agent_copies.len() < copies.len() {
+        return prefer_session_copy(&agent_copies);
+    }
+    if let Ok(cwd) = std::env::current_dir() {
+        let cwd_s = cwd.to_string_lossy();
+        let cwd_hits: Vec<&&Session> = copies
+            .iter()
+            .filter(|s| {
+                !s.project.is_empty()
+                    && (cwd_s == s.project
+                        || cwd_s.starts_with(&format!("{}/", s.project))
+                        || s.project.starts_with(cwd_s.as_ref()))
+            })
+            .collect();
+        if cwd_hits.len() == 1 {
+            return cwd_hits[0];
+        }
+        if let Some(name) = cwd.file_name() {
+            let name = name.to_string_lossy();
+            let named: Vec<&&Session> = copies
+                .iter()
+                .filter(|s| {
+                    Path::new(&s.project)
+                        .file_name()
+                        .is_some_and(|n| n.to_string_lossy() == name)
+                })
+                .collect();
+            if named.len() == 1 {
+                return named[0];
+            }
+        }
+    }
+    copies
+        .iter()
+        .max_by_key(|s| recency_key(s))
+        .copied()
+        .unwrap_or(copies[0])
 }
 
 /// Exact id or *unique* prefix. Ambiguous prefixes resolve to None; callers
@@ -1413,6 +1656,91 @@ mod tests {
     }
 
     #[test]
+    fn resume_command_claude_and_codex() {
+        let claude = make_session("c1", "2026-01-01", "claude", "/p", "", "");
+        assert_eq!(
+            resume_command(&claude),
+            Some(("claude".into(), vec!["--resume".into(), "c1".into()]))
+        );
+        let codex = make_session("x1", "2026-01-01", "codex", "/p", "", "");
+        assert_eq!(
+            resume_command(&codex),
+            Some(("codex".into(), vec!["resume".into(), "x1".into()]))
+        );
+    }
+
+    #[test]
+    fn resume_command_cursor_uses_resume_flag() {
+        let missing = make_session(
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "2026-08-26",
+            "cursor-agent",
+            "/no/such/cursor/ws",
+            "",
+            "",
+        );
+        let (bin, args) = resume_command(&missing).expect("cursor resume");
+        assert!(bin == "agent" || bin == "cursor");
+        assert!(args.iter().any(|a| a == "--resume"));
+        assert!(args.iter().any(|a| a == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"));
+        assert!(!args.iter().any(|a| a == "--workspace"));
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let ws = dir.path().to_string_lossy().into_owned();
+        let present = make_session(
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "2026-08-26",
+            "cursor-agent",
+            &ws,
+            "",
+            "",
+        );
+        let (_, args) = resume_command(&present).expect("cursor resume with workspace");
+        assert!(
+            args.windows(2)
+                .any(|w| w[0] == "--workspace" && w[1] == ws)
+        );
+    }
+
+    #[test]
+    fn resume_working_dir_requires_existing_folder() {
+        let missing = make_session("id", "2026-01-01", "cursor-agent", "/no/such/ws", "", "");
+        assert!(resume_working_dir(&missing).is_none());
+        let dir = tempfile::TempDir::new().unwrap();
+        let present = make_session(
+            "id",
+            "2026-01-01",
+            "cursor-agent",
+            dir.path().to_str().unwrap(),
+            "",
+            "",
+        );
+        assert_eq!(
+            resume_working_dir(&present).as_deref(),
+            Some(dir.path())
+        );
+    }
+
+    #[test]
+    fn cursor_slug_keeps_hyphenated_dir_names() {
+        let root = tempfile::TempDir::new().unwrap();
+        let ws = root.path().join("devops").join("chat-history");
+        fs::create_dir_all(&ws).unwrap();
+        assert_eq!(
+            match_slug_to_existing_path(root.path(), "devops-chat-history"),
+            ws.to_string_lossy()
+        );
+    }
+
+    #[test]
+    fn cursor_slug_falls_back_to_slug_when_path_missing() {
+        assert_eq!(
+            decode_cursor_project_slug("zz-no-such-cursor-ws-xyz"),
+            "zz-no-such-cursor-ws-xyz"
+        );
+    }
+
+    #[test]
     fn encode_path_replaces_all_non_alphanumerics() {
         // Claude Code replaces every non-alphanumeric character with '-',
         // not just '/'; dots and underscores must match its encoding or
@@ -1448,6 +1776,97 @@ mod tests {
             lookup_session(&sessions, "abc-1"),
             SessionLookup::Found(s) if s.id == "abc-123"
         ));
+    }
+
+    #[test]
+    fn merge_cursor_copies_ide_title_onto_agent_transcript() {
+        let agents = vec![make_session(
+            "11111111-2222-3333-4444-555555555555",
+            "2026-08-01",
+            "cursor-agent",
+            "Users-test-myapp",
+            "",
+            "",
+        )];
+        let ide = make_session(
+            "11111111-2222-3333-4444-555555555555",
+            "2026-08-01",
+            "cursor",
+            "/home/alice/src/myapp",
+            "",
+            "Fix the login timeout",
+        );
+        let merged = merge_cursor_sessions(agents, vec![ide]);
+        assert_eq!(merged.len(), 2);
+        let agent = merged.iter().find(|s| s.source == "cursor-agent").unwrap();
+        let ide_row = merged.iter().find(|s| s.source == "cursor").unwrap();
+        assert_eq!(agent.summary, "Fix the login timeout");
+        assert_eq!(agent.project, "/home/alice/src/myapp");
+        assert_eq!(ide_row.summary, "Fix the login timeout");
+    }
+
+    #[test]
+    fn merge_cursor_keeps_ide_row_as_cursor() {
+        let agents = vec![make_session(
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "2026-08-01",
+            "cursor-agent",
+            "Users-test-myapp",
+            "",
+            "",
+        )];
+        let ide = make_session(
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "2026-08-01",
+            "cursor",
+            "/home/alice/src/myapp",
+            "",
+            "Explain the cache layer",
+        );
+        let merged = merge_cursor_sessions(agents, vec![ide]);
+        assert_eq!(merged.len(), 2);
+        assert!(merged.iter().any(|s| s.source == "cursor-agent"));
+        let ide_row = merged.iter().find(|s| s.source == "cursor").unwrap();
+        assert_eq!(ide_row.summary, "Explain the cache layer");
+    }
+
+    #[test]
+    fn lookup_session_same_id_copies_are_not_ambiguous() {
+        let sessions = vec![
+            make_session(
+                "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+                "2025-08-25",
+                "cursor-agent",
+                "/tmp",
+                "",
+                "old copy",
+            ),
+            make_session(
+                "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+                "2025-08-26",
+                "cursor-agent",
+                "/home/alice/src/myapp",
+                "",
+                "new copy",
+            ),
+        ];
+        match lookup_session(&sessions, "bbbbbbbb") {
+            SessionLookup::Found(s) => assert_eq!(s.project, "/home/alice/src/myapp"),
+            other => panic!("expected Found, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lookup_session_prefers_agent_transcript_over_ide_row() {
+        let id = "cccccccc-dddd-eeee-ffff-000000000000";
+        let sessions = vec![
+            make_session(id, "2026-08-26", "cursor", "/home/alice/src/myapp", "", "sidebar title"),
+            make_session(id, "2026-08-20", "cursor-agent", "/home/alice/src/myapp", "", ""),
+        ];
+        match lookup_session(&sessions, id) {
+            SessionLookup::Found(s) => assert_eq!(s.source, "cursor-agent"),
+            other => panic!("expected Found, got {other:?}"),
+        }
     }
 
     #[test]
@@ -1518,7 +1937,7 @@ mod tests {
         let sessions = vec![make_session(
             "1",
             "2025-01-01",
-            "cursor",
+            "cursor-agent",
             "proj-one-two-123",
             "",
             "",
@@ -1670,7 +2089,7 @@ mod tests {
             make_session(
                 "2",
                 "2025-06-15",
-                "cursor",
+                "cursor-agent",
                 "chat-history",
                 "main",
                 "fix docker",

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2442,3 +2442,86 @@ fn cursor_ide_search_json_reports_source_and_also_ide() {
     assert_eq!(first["also_ide"], false);
     assert_eq!(first["session_id"], "abcd1234-0000-4000-8000-000000000001");
 }
+
+// ---------------------------------------------------------------------------
+// Cursor Agent transcripts: resume only through the CLI's own chat store
+// ---------------------------------------------------------------------------
+
+fn setup_cursor_agent_jsonl(tmp: &TempDir, slug: &str, id: &str) {
+    let dir = tmp
+        .path()
+        .join(".cursor")
+        .join("projects")
+        .join(slug)
+        .join("agent-transcripts")
+        .join(id);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join(format!("{id}.jsonl")),
+        r#"{"role":"user","message":{"content":[{"type":"text","text":"probe question about caching"}]}}"#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn cursor_transcript_without_cli_store_prints_sidebar_hint() {
+    let (mut cmd, tmp) = isolated_cmd();
+    let id = "dddd1111-2222-4333-8444-555555555555";
+    setup_cursor_agent_jsonl(&tmp, "Users-test-myapp", id);
+    cmd.env("NO_COLOR", "1")
+        .args(["resume", "dddd1111"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("chat store"))
+        .stdout(predicate::str::contains("Cursor IDE UI"))
+        .stdout(predicate::str::contains(id));
+}
+
+#[cfg(unix)]
+#[test]
+fn cursor_transcript_with_cli_store_resumes_in_its_workspace() {
+    use std::os::unix::fs::PermissionsExt;
+    let (mut cmd, tmp) = isolated_cmd();
+    let id = "dddd2222-2222-4333-8444-555555555555";
+    setup_cursor_agent_jsonl(&tmp, "Users-test-myapp", id);
+    let ws = tmp.path().join("ws");
+    fs::create_dir_all(&ws).unwrap();
+    let store = tmp
+        .path()
+        .join(".cursor")
+        .join("chats")
+        .join("0123abcd")
+        .join(id);
+    fs::create_dir_all(&store).unwrap();
+    fs::write(
+        store.join("meta.json"),
+        format!(
+            r#"{{"schemaVersion":1,"cwd":{:?},"updatedAtMs":1}}"#,
+            ws.to_str().unwrap()
+        ),
+    )
+    .unwrap();
+    // A shim `agent` that only echoes how it was invoked.
+    let bin = tmp.path().join("bin");
+    fs::create_dir_all(&bin).unwrap();
+    let shim = bin.join("agent");
+    fs::write(
+        &shim,
+        "#!/bin/sh\necho \"SHIM agent $*\"\necho \"SHIM cwd $(pwd -P)\"\n",
+    )
+    .unwrap();
+    fs::set_permissions(&shim, fs::Permissions::from_mode(0o755)).unwrap();
+    cmd.env("NO_COLOR", "1")
+        .env("PATH", format!("{}:/usr/bin:/bin", bin.display()))
+        .args(["resume", "dddd2222"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "SHIM agent --resume {id} --workspace {}",
+            ws.display()
+        )))
+        .stdout(predicate::str::contains(format!(
+            "SHIM cwd {}",
+            ws.canonicalize().unwrap().display()
+        )));
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2328,3 +2328,117 @@ fn empty_and_whitespace_messages_still_filtered() {
         "Empty strings and noise patterns should still be filtered, got {count} results"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Cursor IDE (state.vscdb) source
+// ---------------------------------------------------------------------------
+
+/// Minimal `state.vscdb` with one sidebar chat: a header plus one user bubble.
+/// Returns the directory to pass as `CURSOR_USER_DIR`.
+fn setup_cursor_ide_fixture(tmp: &TempDir) -> std::path::PathBuf {
+    let user = tmp.path().join("cursor-user");
+    let dir = user.join("globalStorage");
+    fs::create_dir_all(&dir).unwrap();
+    let conn = rusqlite::Connection::open(dir.join("state.vscdb")).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE composerHeaders (
+            composerId TEXT PRIMARY KEY, workspaceId TEXT, createdAt INTEGER,
+            lastUpdatedAt INTEGER, isArchived INTEGER, isSubagent INTEGER,
+            recency INTEGER, checkpointAt INTEGER, value TEXT);
+         CREATE TABLE cursorDiskKV (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB);",
+    )
+    .unwrap();
+    let id = "abcd1234-0000-4000-8000-000000000001";
+    let header = serde_json::json!({
+        "name": "Explain the cache layer",
+        "unifiedMode": "agent",
+        "workspaceIdentifier": {"uri": {"fsPath": "/home/alice/src/myapp", "path": "/home/alice/src/myapp"}}
+    });
+    conn.execute(
+        "INSERT INTO composerHeaders (composerId, createdAt, lastUpdatedAt, isSubagent, value)
+         VALUES (?1, 1782941109570, 1782941109570, 0, ?2)",
+        rusqlite::params![id, header.to_string()],
+    )
+    .unwrap();
+    let bubble = serde_json::json!({
+        "type": 1,
+        "text": "why does the cache layer miss on warm keys",
+        "bubbleId": "b1",
+        "createdAt": "2026-07-01T10:00:00.000Z"
+    });
+    conn.execute(
+        "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+        rusqlite::params![format!("bubbleId:{id}:b1"), bubble.to_string()],
+    )
+    .unwrap();
+    user
+}
+
+fn cursor_ide_cmd(tmp: &TempDir, user: &std::path::Path) -> Command {
+    let mut cmd = Command::cargo_bin("chat-history").unwrap();
+    cmd.env("CLAUDE_CONFIG_DIR", tmp.path());
+    cmd.env("HOME", tmp.path());
+    cmd.env_remove("CODEX_HOME");
+    cmd.env("CURSOR_USER_DIR", user);
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+#[test]
+fn cursor_ide_source_lists_chat_with_usable_id() {
+    let tmp = TempDir::new().unwrap();
+    let user = setup_cursor_ide_fixture(&tmp);
+    cursor_ide_cmd(&tmp, &user)
+        .args(["--source", "cursor-ide"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("cursor-ide"))
+        .stdout(predicate::str::contains("Explain the cache layer"))
+        .stdout(predicate::str::contains("abcd1234"))
+        .stdout(predicate::str::contains("/home/alice/src/myapp"));
+    // The listed prefix resolves like any other id.
+    cursor_ide_cmd(&tmp, &user)
+        .args(["view", "abcd1234", "--plain"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("warm keys"));
+    cursor_ide_cmd(&tmp, &user)
+        .args(["find", "abcd1234"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("state.vscdb"));
+}
+
+#[test]
+fn cursor_ide_resume_prints_sidebar_hint_instead_of_launching() {
+    let tmp = TempDir::new().unwrap();
+    let user = setup_cursor_ide_fixture(&tmp);
+    cursor_ide_cmd(&tmp, &user)
+        .args(["resume", "abcd1234"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("Cursor IDE UI"))
+        .stdout(predicate::str::contains("/home/alice/src/myapp"))
+        .stdout(predicate::str::contains("Explain the cache layer"))
+        .stdout(predicate::str::contains(
+            "abcd1234-0000-4000-8000-000000000001",
+        ));
+}
+
+#[test]
+fn cursor_ide_search_json_reports_source_and_also_ide() {
+    let tmp = TempDir::new().unwrap();
+    let user = setup_cursor_ide_fixture(&tmp);
+    let out = cursor_ide_cmd(&tmp, &user)
+        .args(["search", "cache", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    let first = &json["results"][0];
+    assert_eq!(first["source"], "cursor-ide");
+    assert_eq!(first["also_ide"], false);
+    assert_eq!(first["session_id"], "abcd1234-0000-4000-8000-000000000001");
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -88,8 +88,7 @@ fn resume_placeholder_id_points_at_ide_ui() {
     cmd.args(["resume", "00000000"])
         .assert()
         .failure()
-        .stdout(predicate::str::contains("Cursor IDE UI"))
-        .stdout(predicate::str::contains("00000000"));
+        .stderr(predicate::str::contains("Session not found"));
 }
 
 #[test]
@@ -333,7 +332,8 @@ fn invalid_source_fails_with_usage_error() {
         .failure()
         .code(2)
         .stderr(predicate::str::contains("possible values"))
-        .stderr(predicate::str::contains("claude"));
+        .stderr(predicate::str::contains("claude"))
+        .stderr(predicate::str::contains("cursor-ide"));
 }
 
 #[test]
@@ -683,6 +683,23 @@ fn filter_by_source_flag() {
         .assert()
         .success()
         .stdout(predicate::str::contains("No sessions found"));
+}
+
+#[test]
+fn source_cursor_and_alias_list_agent_transcripts() {
+    let tmp = TempDir::new().unwrap();
+    setup_cursor_fixture(&tmp);
+    for src in ["cursor", "cursor-agent"] {
+        Command::cargo_bin("chat-history")
+            .unwrap()
+            .args(["--source", src])
+            .env("HOME", tmp.path())
+            .env("CLAUDE_CONFIG_DIR", tmp.path())
+            .env("NO_COLOR", "1")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("refactor the database module"));
+    }
 }
 
 #[test]
@@ -1818,7 +1835,7 @@ fn cursor_sessions_listed() {
         "should show cursor session's first prompt"
     );
     assert!(
-        stdout.contains("cursor-agent"),
+        stdout.contains("cursor"),
         "should show agent tag for cursor sessions"
     );
     assert!(
@@ -2146,7 +2163,7 @@ fn mixed_sources_both_listed() {
         "should show Claude sessions with claude tag"
     );
     assert!(
-        stdout.contains("cursor-agent"),
+        stdout.contains("cursor"),
         "should show Cursor sessions with agent tag"
     );
     assert!(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -83,6 +83,16 @@ fn find_missing_session() {
 }
 
 #[test]
+fn resume_placeholder_id_points_at_ide_ui() {
+    let (mut cmd, _tmp) = isolated_cmd();
+    cmd.args(["resume", "00000000"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("Cursor IDE UI"))
+        .stdout(predicate::str::contains("00000000"));
+}
+
+#[test]
 fn install_skill_creates_files() {
     let tmp = TempDir::new().unwrap();
     Command::cargo_bin("chat-history")
@@ -311,6 +321,7 @@ fn list_title_is_single_line_without_preamble() {
         .assert()
         .success()
         .stdout(predicate::str::contains("fix the flaky test suite"))
+        .stdout(predicate::str::contains("/Users/test/noisy"))
         .stdout(predicate::str::contains("manually_attached_skills").not());
 }
 
@@ -567,7 +578,7 @@ fn claude_jsonl_only_session_lists_ai_title_and_branch() {
         .assert()
         .success()
         .stdout(predicate::str::contains("Login form validation"))
-        .stdout(predicate::str::contains("(feat-login)"));
+        .stdout(predicate::str::contains("BRANCH: feat-login"));
 }
 
 #[test]
@@ -626,7 +637,9 @@ fn search_index_finds_session() {
         .env("HOME", tmp.path())
         .assert()
         .success()
-        .stdout(predicate::str::contains("docker deployment pipeline"));
+        .stdout(predicate::str::contains("docker deployment pipeline"))
+        .stdout(predicate::str::contains("DIR:"))
+        .stdout(predicate::str::contains("INDEX_FIELD:"));
 }
 
 #[test]
@@ -664,7 +677,7 @@ fn filter_by_source_flag() {
     // All fixture sessions are claude source
     Command::cargo_bin("chat-history")
         .unwrap()
-        .args(["--source", "cursor"])
+        .args(["--source", "cursor-agent"])
         .env("CLAUDE_CONFIG_DIR", tmp.path())
         .env("HOME", tmp.path())
         .assert()
@@ -1804,6 +1817,73 @@ fn cursor_sessions_listed() {
         stdout.contains("refactor the database module"),
         "should show cursor session's first prompt"
     );
+    assert!(
+        stdout.contains("cursor-agent"),
+        "should show agent tag for cursor sessions"
+    );
+    assert!(
+        stdout.contains("Users-test-myapp"),
+        "should show the cursor workspace directory slug"
+    );
+}
+
+fn setup_cursor_duplicate_id_fixture(tmp: &TempDir) {
+    let session_id = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff";
+    for (slug, prompt) in [
+        ("tmp-scratch", "old copy from tmp workspace"),
+        ("Users-test-myapp", "continued copy in myapp"),
+    ] {
+        let dir = tmp
+            .path()
+            .join(".cursor")
+            .join("projects")
+            .join(slug)
+            .join("agent-transcripts")
+            .join(session_id);
+        fs::create_dir_all(&dir).unwrap();
+        let line = serde_json::json!({
+            "role": "user",
+            "message": {"content": [{"type": "text", "text": prompt}]}
+        });
+        fs::write(
+            dir.join(format!("{session_id}.jsonl")),
+            serde_json::to_string(&line).unwrap(),
+        )
+        .unwrap();
+    }
+}
+
+#[test]
+fn duplicate_cursor_session_id_lists_copies_and_resolves() {
+    let tmp = TempDir::new().unwrap();
+    setup_cursor_duplicate_id_fixture(&tmp);
+
+    let list = Command::cargo_bin("chat-history")
+        .unwrap()
+        .env("HOME", tmp.path())
+        .env("CLAUDE_CONFIG_DIR", tmp.path())
+        .env("NO_COLOR", "1")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(list.stdout).unwrap();
+    assert!(list.status.success());
+    assert!(
+        stdout.contains("COPIES: 2"),
+        "duplicate ids should be labeled: {stdout}"
+    );
+
+    Command::cargo_bin("chat-history")
+        .unwrap()
+        .args(["find", "bbbbbbbb"])
+        .env("HOME", tmp.path())
+        .env("CLAUDE_CONFIG_DIR", tmp.path())
+        .env("NO_COLOR", "1")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("stored in 2"))
+        .stdout(predicate::str::contains(
+            "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+        ));
 }
 
 #[test]
@@ -1852,7 +1932,7 @@ fn cursor_subagent_sessions_hidden_by_default() {
 
     Command::cargo_bin("chat-history")
         .unwrap()
-        .args(["--source", "cursor"])
+        .args(["--source", "cursor-agent"])
         .env("HOME", tmp.path())
         .env("CLAUDE_CONFIG_DIR", tmp.path())
         .env("NO_COLOR", "1")
@@ -1866,7 +1946,7 @@ fn cursor_subagent_sessions_hidden_by_default() {
             "search",
             "subagent analysis",
             "--source",
-            "cursor",
+            "cursor-agent",
             "--deep",
         ])
         .env("HOME", tmp.path())
@@ -1885,7 +1965,7 @@ fn cursor_subagent_sessions_listed_and_searchable_with_flag() {
 
     Command::cargo_bin("chat-history")
         .unwrap()
-        .args(["--source", "cursor", "--sidechains"])
+        .args(["--source", "cursor-agent", "--sidechains"])
         .env("HOME", tmp.path())
         .env("CLAUDE_CONFIG_DIR", tmp.path())
         .env("NO_COLOR", "1")
@@ -1900,7 +1980,7 @@ fn cursor_subagent_sessions_listed_and_searchable_with_flag() {
             "search",
             "subagent analysis",
             "--source",
-            "cursor",
+            "cursor-agent",
             "--deep",
             "--sidechains",
         ])
@@ -2062,12 +2142,12 @@ fn mixed_sources_both_listed() {
         .unwrap();
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(
-        stdout.contains("CC"),
-        "should show Claude sessions with CC tag"
+        stdout.contains("claude"),
+        "should show Claude sessions with claude tag"
     );
     assert!(
-        stdout.contains("CR"),
-        "should show Cursor sessions with CR tag"
+        stdout.contains("cursor-agent"),
+        "should show Cursor sessions with agent tag"
     );
     assert!(
         stdout.contains("3 sessions"),


### PR DESCRIPTION
This adds Cursor IDE chats from the local SQLite DB alongside Agent transcripts, Claude Code, and Codex. List and search label IDE rows as cursor and Agent logs as cursor-agent, show spawn directories with ~, and use generic test fixtures so the change is reviewable upstream.

- Keep index hits on sidebar titles instead of dropping them as too weak
- Treat the same composer id in multiple folders as copies, not ambiguous
- Show 00000000 for IDE rows; resume 00000000 points users at the Cursor UI

Co-authored-by: Cursor using Grok 4.6